### PR TITLE
Add explicit endpoints

### DIFF
--- a/EndPoint.cs
+++ b/EndPoint.cs
@@ -42,19 +42,17 @@ namespace RhinoCommon.Rest
             if(explicitPath)
             {
                 var parameters = methods[0].GetParameters();
-                bool isStatic = methods[0].IsStatic;
                 var extra = new System.Text.StringBuilder();
-                if(!isStatic)
+                bool dashAdded = false;
+                if(!methods[0].IsStatic)
                 {
                     extra.Append($"-{classType.Name}");
+                    dashAdded = true;
                 }
                 for(int i=0; i<parameters.Length; i++ )
                 {
-                    if (0 == i && !isStatic)
-                        extra.Append("-");
-                    else
-                        extra.Append("_");
-                        
+                    extra.Append(dashAdded ? "_" : "-");
+                    dashAdded = true;
 
                     var parameter = parameters[i];
                     var type = parameter.ParameterType;
@@ -159,7 +157,11 @@ namespace RhinoCommon.Rest
         {
             string path = Path;
             int index = path.LastIndexOf("/");
-            return path.Substring(index + 1);
+            string funcname = path.Substring(index + 1);
+            index = funcname.IndexOf("-");
+            if (index > 0)
+                funcname = funcname.Substring(0, index);
+            return funcname;
         }
 
         public virtual Nancy.Response HandleGetAsResponse(NancyContext context)

--- a/EndPointDictionary.cs
+++ b/EndPointDictionary.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace RhinoCommon.Rest
+{
+    /// <summary>
+    /// Master list of all endpoints (URLs) that the compute server supports
+    /// </summary>
+    static class EndPointDictionary
+    {
+        static Dictionary<string, EndPoint> _dictionary;
+
+        /// <summary>
+        /// Dictionary of all endpoints in the form of a URL and a EndPoint
+        /// handler for that endpoint. We use a dictionary instead of a simple
+        /// list to ensure there are no conflicting endpoints that are trying
+        /// to use the same URL (this would throw an ArgumentException when
+        /// calling add)
+        /// </summary>
+        /// <returns>
+        /// Dictionary of all endpoints that this server supports
+        /// </returns>
+        public static Dictionary<string, EndPoint> GetDictionary()
+        {
+            if (_dictionary != null)
+                return _dictionary;
+
+            _dictionary = new Dictionary<string, EndPoint>();
+            AddEndPoint(_dictionary, EndPoint.Create("", FixedEndpoints.HomePage));
+            AddEndPoint(_dictionary, EndPoint.Create("version", FixedEndpoints.GetVersion));
+            AddEndPoint(_dictionary, EndPoint.Create("sdk/csharp", FixedEndpoints.CSharpSdk));
+            AddEndPoint(_dictionary, EndPoint.Create("hammertime", FixedEndpoints.HammerTime));
+
+            AddEndPoint(_dictionary, new ListSdkEndPoint());
+            BuildApi(_dictionary, typeof(Rhino.RhinoApp).Assembly, "Rhino.Geometry");
+            BuildApi(_dictionary, typeof(Rhino.RhinoApp).Assembly, "Rhino.Geometry.Intersect");
+            return _dictionary;
+        }
+
+        static void AddEndPoint(Dictionary<string, EndPoint> dict, EndPoint endpoint)
+        {
+            string key = endpoint.Path.ToLowerInvariant();
+            dict.Add(key, endpoint);
+        }
+
+        static void BuildApi(Dictionary<string, EndPoint> dict, Assembly assembly, string nameSpace)
+        {
+            foreach (var export in assembly.GetExportedTypes())
+            {
+                if (!string.Equals(export.Namespace, nameSpace, StringComparison.Ordinal))
+                    continue;
+                if (export.IsInterface || export.IsEnum)
+                    continue;
+                if (export.IsClass || export.IsValueType)
+                {
+                    var endpoints = EndPoint.Create(export);
+                    foreach (var endpoint in endpoints)
+                    {
+                        string key = endpoint.Path.ToLowerInvariant();
+                        try
+                        {
+                            AddEndPoint(dict, endpoint);
+                        }
+                        catch (Exception)
+                        {
+                            //throw away exception for now
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/FixedEndpoints.cs
+++ b/FixedEndpoints.cs
@@ -7,6 +7,11 @@ namespace RhinoCommon.Rest
 {
     public static class FixedEndpoints
     {
+        public static Response HomePage(NancyContext ctx)
+        {
+            return new Nancy.Responses.RedirectResponse("https://www.rhino3d.com/compute");
+        }
+
         public static Response GetVersion(NancyContext ctx)
         {
             var values = new Dictionary<string, string>();
@@ -14,6 +19,29 @@ namespace RhinoCommon.Rest
             values.Add("Compute", Assembly.GetExecutingAssembly().GetName().Version.ToString());
             var response = (Nancy.Response)Newtonsoft.Json.JsonConvert.SerializeObject(values);
             response.ContentType = "application/json";
+            return response;
+        }
+
+        public static Response CSharpSdk(NancyContext ctx)
+        {
+            string content = "";
+            using (var resourceStream = typeof(FixedEndpoints).Assembly.GetManifestResourceStream("RhinoCommon.Rest.RhinoCompute.cs"))
+            {
+                var stream = new System.IO.StreamReader(resourceStream);
+                content = stream.ReadToEnd();
+                stream.Close();
+            }
+
+            var response = new Response();
+
+            response.Headers.Add("Content-Disposition", "attachment; filename=RhinoCompute.cs");
+            response.ContentType = "text/plain";
+            response.Contents = stream => {
+                using (var writer = new System.IO.StreamWriter(stream))
+                {
+                    writer.Write(content);
+                }
+            };
             return response;
         }
 
@@ -58,3 +86,4 @@ namespace RhinoCommon.Rest
         }
     }
 }
+

--- a/Program.cs
+++ b/Program.cs
@@ -169,20 +169,19 @@ namespace RhinoCommon.Rest
                         Logger.WriteInfo($"POST {kv.Key}", auth_user as string);
                     var jsonString = Request.Body.AsString();
 
-                    // In order to enable CORS, we add the proper headers to the response
                     var resp = new Nancy.Response();
                     resp.Contents = (e) =>
                     {
                         using (var sw = new System.IO.StreamWriter(e))
                         {
                             bool multiple = false;
-                            System.Collections.Generic.Dictionary<string, string> returnModifiers = null;
+                            Dictionary<string, string> returnModifiers = null;
                             foreach(string name in Request.Query)
                             {
                                 if( name.StartsWith("return.", StringComparison.InvariantCultureIgnoreCase))
                                 {
                                     if (returnModifiers == null)
-                                        returnModifiers = new System.Collections.Generic.Dictionary<string, string>();
+                                        returnModifiers = new Dictionary<string, string>();
                                     string dataType = "Rhino.Geometry." + name.Substring("return.".Length);
                                     string items = Request.Query[name];
                                     returnModifiers[dataType] = items;

--- a/RhinoCommon.Rest.csproj
+++ b/RhinoCommon.Rest.csproj
@@ -147,6 +147,7 @@
     <Compile Include="Authentication\ApiKey.cs" />
     <Compile Include="Authentication\RhinoAccounts.cs" />
     <Compile Include="EndPoint.cs" />
+    <Compile Include="EndPointDictionary.cs" />
     <Compile Include="Environment.cs" />
     <Compile Include="FixedEndpoints.cs" />
     <Compile Include="Logger.cs" />


### PR DESCRIPTION
Adding explicit endpoints that map to a single function in RhinoCommon. We are still supporting the endpoint that performs a best guess at the overload to call.