### PR TITLE
Improvements to make compute play nicer with CodeDeploy

### DIFF
--- a/.codedeploy/appspec.yml
+++ b/.codedeploy/appspec.yml
@@ -77,12 +77,16 @@ hooks:
 # During the ApplicationStop deployment lifecycle event, run the commands 
 #   in the script specified in "location" starting from the root of the 
 #   revision's file bundle.
-  ApplicationStop:
-    - location: scripts/stop.bat
-      timeout: 300
+#   ApplicationStop:
+#     - location: scripts/stop.bat
+#       timeout: 300
 # During the BeforeInstall deployment lifecycle event, run the commands 
 #   in the script specified in "location".
+# NOTE: Run stop.bat here because it needs to be run for the first deployment
+# to new instances in an ASG.
   BeforeInstall:
+    - location: scripts/stop.bat
+      timeout: 300
     - location: scripts/clean.bat
       timeout: 300
 # During the AfterInstall deployment lifecycle event, run the commands 

--- a/src/compute.frontend/compute.frontend.csproj
+++ b/src/compute.frontend/compute.frontend.csproj
@@ -56,12 +56,6 @@
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Rhino.UI, Version=7.0.18246.23570, Culture=neutral, PublicKeyToken=552281e97c755530, processorArchitecture=MSIL">
-      <HintPath>..\packages\RhinoCommon.7.0.18246.23575-wip\lib\net45\Rhino.UI.dll</HintPath>
-    </Reference>
-    <Reference Include="RhinoCommon, Version=7.0.18246.23570, Culture=neutral, PublicKeyToken=552281e97c755530, processorArchitecture=MSIL">
-      <HintPath>..\packages\RhinoCommon.7.0.18246.23575-wip\lib\net45\RhinoCommon.dll</HintPath>
-    </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\packages\Serilog.2.7.1\lib\net46\Serilog.dll</HintPath>
     </Reference>
@@ -141,5 +135,4 @@
     </ItemGroup>
     <Delete Files="@(FilesToDelete)" />
   </Target>
-  <Import Project="..\packages\RhinoCommon.7.0.18246.23575-wip\build\net45\RhinoCommon.targets" Condition="Exists('packages\RhinoCommon.7.0.18246.23575-wip\build\net45\RhinoCommon.targets')" />
 </Project>

--- a/src/compute.frontend/packages.config
+++ b/src/compute.frontend/packages.config
@@ -7,7 +7,6 @@
   <package id="Nancy.Gzip" version="0.1.0" targetFramework="net462" />
   <package id="Nancy.Hosting.Self" version="1.4.1" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net462" />
-  <package id="RhinoCommon" version="7.0.18246.23575-wip" targetFramework="net462" />
   <package id="Serilog" version="2.7.1" targetFramework="net462" />
   <package id="Serilog.Sinks.AwsCloudWatch" version="4.0.131" targetFramework="net462" />
   <package id="Serilog.Sinks.Console" version="3.1.1" targetFramework="net462" />


### PR DESCRIPTION
* Stop service during `BeforeInstall` instead of `ApplicationStop` because the latter doesn't run for the very first deployment and we might be deploying onto fresh instances launched by the ASG
* Use EC2 instance ID instead of hostname, if available
* Remove RhinoCommon dep from frontend since it's not necessary and was getting copylocal'd; `/version` now reports the proper Rhino WIP version number, not the copylocal'd RhinoCommon.dll version.

See COMPUTE-6