### PR TITLE
Add module.exports line to make compute.rhino3d.js work with node.js and fix computegen console colour

### DIFF
--- a/src/compute.client/JavascriptClient.cs
+++ b/src/compute.client/JavascriptClient.cs
@@ -83,7 +83,9 @@ namespace computegen
               return
 @"};
 
-module.exports = RhinoCompute;"; // export RhinoCompute object for use in node.js
+// export RhinoCompute object if node.js
+if (typeof exports === 'object' && typeof module === 'object')
+    module.exports = RhinoCompute;";
             }
         }
 

--- a/src/compute.client/JavascriptClient.cs
+++ b/src/compute.client/JavascriptClient.cs
@@ -78,7 +78,13 @@ namespace computegen
 
         protected override string Suffix
         {
-            get { return "};"; }
+            get
+            {
+              return
+@"};
+
+module.exports = RhinoCompute;"; // export RhinoCompute object for use in node.js
+            }
         }
 
         protected override string ToComputeClient(ClassBuilder cb)

--- a/src/compute.client/Program.cs
+++ b/src/compute.client/Program.cs
@@ -31,7 +31,8 @@ namespace computegen
             Console.WriteLine("Writing C# client");
             var cs = new DotNetClient();
             cs.Write(ClassBuilder.AllClasses, "RhinoCompute.cs", filter);
-        }
 
+            Console.ResetColor();
+        }
     }
 }


### PR DESCRIPTION
A couple of quick fixes...

The former makes it possible to `compute = require('./compute.rhino3d.js')` in node.js – assuming compute.rhino3d.js is in the same directory as the calling code (or we could publish an npm package).