### PR TITLE
Remote parameter support and parameter caching

### DIFF
--- a/src/compute.geometry/DataCache.cs
+++ b/src/compute.geometry/DataCache.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace compute.geometry
+{
+    static class DataCache
+    {
+        public static object GetCachedItem(JToken token, Type objectType, JsonSerializer serializer)
+        {
+            string jsonString = token.ToString();
+            if (jsonString.StartsWith("{") &&
+                jsonString.EndsWith("}") &&
+                jsonString.IndexOf("url", StringComparison.OrdinalIgnoreCase)>0 &&
+                jsonString.IndexOf("http", StringComparison.OrdinalIgnoreCase)>0)
+            {
+                Dictionary<string, string> cacheDictionary = new Dictionary<string, string>();
+                cacheDictionary = token.ToObject(cacheDictionary.GetType()) as Dictionary<string, string>;
+                string url;
+                if (cacheDictionary == null || !cacheDictionary.TryGetValue("url", out url))
+                    return null;
+
+                JToken jtoken = null;
+                string key = $"url:{url.ToLower()}";
+                Tuple<JToken, object> cacheEntry = System.Runtime.Caching.MemoryCache.Default.Get(key) as Tuple<JToken, object>;
+                if( cacheEntry!=null)
+                {
+                    Rhino.Geometry.GeometryBase geometry = cacheEntry.Item2 as Rhino.Geometry.GeometryBase;
+                    if (geometry != null)
+                        return geometry.DuplicateShallow();
+                    jtoken = cacheEntry.Item1;
+                }
+                if (jtoken == null)
+                {
+                    using (var client = new System.Net.WebClient())
+                    {
+                        string cacheString = client.DownloadString(url);
+                        object data = string.IsNullOrWhiteSpace(cacheString) ? null : Newtonsoft.Json.JsonConvert.DeserializeObject(cacheString);
+                        var ja = data as Newtonsoft.Json.Linq.JArray;
+                        jtoken = ja[0];
+                    }
+                }
+
+                if( jtoken!=null )
+                {
+                    object rc = null;
+                    if (serializer == null)
+                        rc = jtoken.ToObject(objectType);
+                    else
+                        rc = jtoken.ToObject(objectType, serializer);
+
+                    cacheEntry = new Tuple<JToken, object>(jtoken, rc);
+                    System.Runtime.Caching.MemoryCache.Default.Add(key, cacheEntry, CachePolicy);
+                    Rhino.Geometry.GeometryBase geometry = rc as Rhino.Geometry.GeometryBase;
+                    if (geometry != null)
+                        return geometry.DuplicateShallow();
+                    return rc;
+                }
+            }
+            return null;
+        }
+
+        private static System.Runtime.Caching.CacheItemPolicy CachePolicy
+        {
+            get
+            {
+                var policy = new System.Runtime.Caching.CacheItemPolicy();
+                // no policy yet, but we could do things like evict after 2 weeks with
+                //policy.SlidingExpiration = new TimeSpan(14, 0, 0, 0);
+                return policy;
+            }
+        }
+    }
+}

--- a/src/compute.geometry/GeometryEndPoint.cs
+++ b/src/compute.geometry/GeometryEndPoint.cs
@@ -442,12 +442,30 @@ namespace compute.geometry
                                 {
                                     var jsonobject = ja[currentJa++];
                                     var generics = methodParameters[i].ParameterType.GetGenericArguments();
+
+                                    Type objectType = null;
+                                    bool useSerializer = true;
                                     if (generics == null || generics.Length != 1)
-                                        invokeParameters[i] = jsonobject.ToObject(methodParameters[i].ParameterType, serializer);
+                                    {
+                                        objectType = methodParameters[i].ParameterType;
+                                        useSerializer = true;
+                                    }
                                     else
                                     {
-                                        var arrayType = generics[0].MakeArrayType();
-                                        invokeParameters[i] = jsonobject.ToObject(arrayType);
+                                        objectType = generics[0].MakeArrayType();
+                                        useSerializer = false;
+                                    }
+
+
+                                    invokeParameters[i] = DataCache.GetCachedItem(jsonobject, objectType, useSerializer ? serializer : null);
+
+
+                                    if (invokeParameters[i] == null)
+                                    {
+                                        if (useSerializer)
+                                            invokeParameters[i] = jsonobject.ToObject(objectType, serializer);
+                                        else
+                                            invokeParameters[i] = jsonobject.ToObject(objectType);
                                     }
                                 }
 

--- a/src/compute.geometry/compute.geometry.csproj
+++ b/src/compute.geometry/compute.geometry.csproj
@@ -95,6 +95,7 @@
     <Reference Include="System.Net.Http, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Net.Http.4.3.1\lib\net46\System.Net.Http.dll</HintPath>
     </Reference>
+    <Reference Include="System.Runtime.Caching" />
     <Reference Include="System.Security.Cryptography.Algorithms, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net461\System.Security.Cryptography.Algorithms.dll</HintPath>
     </Reference>
@@ -121,6 +122,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DataCache.cs" />
     <Compile Include="Environment.cs" />
     <Compile Include="FixedEndpoints.cs" />
     <Compile Include="GeometryEndPoint.cs" />


### PR DESCRIPTION
Remote parameters
All parameters can now be passed as a dictionary of
{"url":"http address to data"}
Data will be fetched from the remote URL and cached on the local compute server in case it is requested again.