### PR TITLE
Also Windows 10 Pro clients can run Rhino Compute.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A REST api exposing Rhino's geometry core. This project has two web services: `c
 ## Getting Started
 
 1. Get the [latest build](https://ci.appveyor.com/project/mcneel/compute-rhino3d/branch/master/artifacts) from the `master` branch (or [build from source](#building-from-source)).
-1. Create a Windows Server 2016 computer.
+1. Create a Windows Server 2016 computer. (Also a Windows 10 desktop computer with Rhino installed can be used, typically for developers sending debug requests to localhost).
 1. Remote desktop onto server.
 1. Copy `src/bin/Release` to the server.
 1. Install Rhino using PowerShell\* (as administrator):


### PR DESCRIPTION
Added that also desktop Windows 10 Pro clients (can other OS be used as well?) and not only Server 2016 can run Compute on developer's local machines. 

This is an important additional statement since the original statement gives the impression that that only Server 2016 can be used, pushing away developers who don't have access to, or don't want to, install an additional server.