### PR TITLE
Proper /healthcheck (take 2)

### DIFF
--- a/src/compute.frontend/NancyPipelineExtensions.cs
+++ b/src/compute.frontend/NancyPipelineExtensions.cs
@@ -60,7 +60,7 @@ namespace compute.frontend
 
         private static void LogResponse(NancyContext context)
         {
-            if (context.Request.Path == "/healthcheck")
+            if (context.Request.Path == "/healthcheck" && context.Response.StatusCode == Nancy.HttpStatusCode.OK)
                 return;
 
             Log.ForContext<Nancy.Response>()

--- a/src/compute.frontend/Proxy.cs
+++ b/src/compute.frontend/Proxy.cs
@@ -9,8 +9,6 @@ namespace compute.frontend
         {
             int backendPort = Env.GetEnvironmentInt("COMPUTE_BACKEND_PORT", 8081);
 
-            Get["/healthcheck"] = _ => "healthy";
-
             Get["/"] =
             Get["/{uri*}"] = _ =>
             {
@@ -23,7 +21,7 @@ namespace compute.frontend
                 }
                 catch
                 {
-                    return 500;
+                    return new Nancy.Responses.TextResponse(Nancy.HttpStatusCode.InternalServerError, "Backend not available");
                 }
             };
 


### PR DESCRIPTION
Removes the `/healthcheck` endpoint from the frontend so that it gets passed through the proxy to the backend. This way we'll know if the backend is down. Along the way I found that compute doesn't like it when the `Host` header from the original request is passed through to the backend in certain circumstances. The requests from AWS` health checker come back with 400 Bad Request (invalid hostname) errors. This also happens for any request when running compute in Docker.

TL;DR:

* `/healthcheck` now handled by the backend
* `Host` header from original request is no longer passed to the backend