### PR TITLE
Resthopper: Add endpoint to expose list of grasshopper components on server

### DIFF
--- a/src/compute.geometry/ResthopperEndpoints.cs
+++ b/src/compute.geometry/ResthopperEndpoints.cs
@@ -20,6 +20,7 @@ namespace compute.geometry
     {
         public string Guid { get; set; }
         public string Name { get; set; }
+        public string NickName { get; set; }
         public string Description { get; set; }
         public string Category { get; set; }
         public string Subcategory { get; set; }
@@ -39,16 +40,16 @@ namespace compute.geometry
     {
         public string Name { get; set; }
         public string NickName { get; set; }
-        public string InstanceDescription { get; set; }
-        public bool Optional { get; set; }
+        public string Description { get; set; }
+        public bool IsOptional { get; set; }
         public string TypeName { get; set; }
 
         public ResthopperComponentParameter(IGH_Param param)
         {
             Name = param.Name;
             NickName = param.NickName;
-            InstanceDescription = param.InstanceDescription;
-            Optional = param.Optional;
+            Description = param.InstanceDescription;
+            IsOptional = param.Optional;
             TypeName = param.TypeName;
         }
     }
@@ -73,6 +74,7 @@ namespace compute.geometry
                 var rc = new ResthopperComponent();
                 rc.Guid = proxies[i].Guid.ToString();
                 rc.Name = proxies[i].Desc.Name;
+                rc.NickName = proxies[i].Desc.NickName;
                 rc.Description = proxies[i].Desc.Description;
                 rc.Category = proxies[i].Desc.HasCategory ? proxies[i].Desc.Category : "";
                 rc.Subcategory = proxies[i].Desc.HasSubCategory ? proxies[i].Desc.SubCategory : "";

--- a/src/compute.geometry/ResthopperEndpoints.cs
+++ b/src/compute.geometry/ResthopperEndpoints.cs
@@ -28,6 +28,8 @@ namespace compute.geometry
         public List<ResthopperComponentParameter> Inputs { get; set; }
         public List<ResthopperComponentParameter> Outputs { get; set; }
 
+        public string LibraryName { get; set; }
+
         public ResthopperComponent()
         {
             Inputs = new List<ResthopperComponentParameter>();
@@ -67,6 +69,16 @@ namespace compute.geometry
         {
             var objs = new List<ResthopperComponent>();
 
+            // Convert ReadOnlyCollection of libraries to list for easy searching
+            var libraries = new List<GH_AssemblyInfo>();
+
+            var gha = Grasshopper.Instances.ComponentServer.Libraries;
+            for (int i = 0; i < gha.Count; i++)
+            {
+                libraries.Add(gha[i]);
+            }
+
+            // Convert Object Proxies to Resthopper Components
             var proxies = Grasshopper.Instances.ComponentServer.ObjectProxies;
 
             for (int i = 0; i < proxies.Count; i++)
@@ -79,6 +91,8 @@ namespace compute.geometry
                 rc.Category = proxies[i].Desc.HasCategory ? proxies[i].Desc.Category : "";
                 rc.Subcategory = proxies[i].Desc.HasSubCategory ? proxies[i].Desc.SubCategory : "";
                 rc.IsObsolete = proxies[i].Obsolete;
+
+                rc.LibraryName = libraries.Find(x => x.Id == proxies[i].LibraryGuid).Name;
 
                 var obj = proxies[i].CreateInstance() as IGH_Component;
 

--- a/src/compute.geometry/ResthopperEndpoints.cs
+++ b/src/compute.geometry/ResthopperEndpoints.cs
@@ -16,15 +16,18 @@ using System.Net;
 namespace compute.geometry
 {
     [JsonObject(MemberSerialization.OptOut)]
-    public class ResthopperComponenet
+    public class ResthopperComponent
     {
-        public string Name { get; set; }
         public string Guid { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public string Category { get; set; }
+        public string Subcategory { get; set; }
         public bool IsObsolete { get; set; }
         public List<ResthopperComponentParameter> Inputs { get; set; }
         public List<ResthopperComponentParameter> Outputs { get; set; }
 
-        public ResthopperComponenet()
+        public ResthopperComponent()
         {
             Inputs = new List<ResthopperComponentParameter>();
             Outputs = new List<ResthopperComponentParameter>();
@@ -61,15 +64,18 @@ namespace compute.geometry
 
         static Response TranspileGrasshopperAssemblies(NancyContext ctx)
         {
-            var objs = new List<ResthopperComponenet>();
+            var objs = new List<ResthopperComponent>();
 
             var proxies = Grasshopper.Instances.ComponentServer.ObjectProxies;
 
             for (int i = 0; i < proxies.Count; i++)
             {
-                var rc = new ResthopperComponenet();
-                rc.Name = proxies[i].Desc.Name;
+                var rc = new ResthopperComponent();
                 rc.Guid = proxies[i].Guid.ToString();
+                rc.Name = proxies[i].Desc.Name;
+                rc.Description = proxies[i].Desc.Description;
+                rc.Category = proxies[i].Desc.HasCategory ? proxies[i].Desc.Category : "";
+                rc.Subcategory = proxies[i].Desc.HasSubCategory ? proxies[i].Desc.SubCategory : "";
                 rc.IsObsolete = proxies[i].Obsolete;
 
                 var obj = proxies[i].CreateInstance() as IGH_Component;


### PR DESCRIPTION
As shared on the forums [here](https://discourse.mcneel.com/t/client-side-ghx-composition-poc/91412), I'm currently working on client-side composition of ghx markup. Part of the exercise is doing some automatic code generation based on the loaded grasshopper assemblies.

David pointed me to a runtime check of `Grasshopper.Instances.ComponentServer`. This works really well, so I added this endpoint on my machine, but I figured it might be more generally useful. 

Exposing this information would allow users to know what's available on any given compute server that they're interacting with. Could be useful to know if a server has certain dependencies?