### PR TITLE
Allow alternative auth method to work with CORS

### DIFF
--- a/src/compute.frontend/Frontend.cs
+++ b/src/compute.frontend/Frontend.cs
@@ -105,7 +105,6 @@ namespace compute.frontend
         {
             // Set up compute to run on a secondary process
             // Proxy requests through to the backend process.
-            string backendPort = Env.GetEnvironmentString("COMPUTE_BACKEND_PORT", "8081");
             var info = new System.Diagnostics.ProcessStartInfo();
             info.UseShellExecute = false;
             foreach (System.Collections.DictionaryEntry entry in Environment.GetEnvironmentVariables())
@@ -115,7 +114,7 @@ namespace compute.frontend
 
             info.FileName = "compute.geometry.exe";
 
-            Log.Information("Starting back-end geometry service on port {Port}", backendPort);
+            Log.Information("Spawning back-end geometry service");
             _backendProcess = System.Diagnostics.Process.Start(info);
             _backendProcess.EnableRaisingEvents = true;
             _backendProcess.Exited += _backendProcess_Exited;

--- a/src/compute.frontend/NancyPipelineExtensions.cs
+++ b/src/compute.frontend/NancyPipelineExtensions.cs
@@ -145,9 +145,16 @@ namespace compute.frontend
                     using (var stream = new MemoryStream())
                     {
                         ctx.Response.Contents.Invoke(stream);
-
-                        logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(
-                            "ResponseContentLength", stream.Length));
+                        try
+                        {
+                            logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(
+                                "ResponseContentLength", stream.Length));
+                        }
+                        catch (ObjectDisposedException)
+                        {
+                            // skip logging content length if stream is prematurely closed
+                            // seems to happen a lot when debugging
+                        }
                     }
 
                     logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty(

--- a/src/compute.frontend/NancyPipelineExtensions.cs
+++ b/src/compute.frontend/NancyPipelineExtensions.cs
@@ -55,7 +55,7 @@ namespace compute.frontend
         {
             context.Response.Headers.Add("Access-Control-Allow-Origin", "*");
             context.Response.Headers.Add("Access-Control-Allow-Methods", "OPTIONS,POST,GET,HEAD");
-            context.Response.Headers.Add("Access-Control-Allow-Headers", "Authorization,Origin,Accept,Content-Type,User-Agent,Access-Control-Allow-Headers,Access-Control-Request-Method,Access-Control-Request-Headers");
+            context.Response.Headers.Add("Access-Control-Allow-Headers", "Authorization,Origin,Accept,Content-Type,User-Agent,Access-Control-Allow-Headers,Access-Control-Request-Method,Access-Control-Request-Headers,api_token");
         }
 
         private static void LogResponse(NancyContext context)

--- a/src/compute.frontend/Proxy.cs
+++ b/src/compute.frontend/Proxy.cs
@@ -1,8 +1,10 @@
-﻿using Nancy.Extensions;
+﻿using Nancy;
+using Nancy.Extensions;
 using Serilog;
 using System;
 using System.Linq;
 using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace compute.frontend
 {
@@ -26,41 +28,41 @@ namespace compute.frontend
             Get["/{uri*}"] = _ =>
             {
                 var proxy_url = GetProxyUrl((string)_.uri, backendPort, Context.Request.Query);
-                var client = CreateProxyClient(Context);
-                try
-                {
-                    var backendResponse = client.GetAsync(proxy_url).Result;
-                    return CreateProxyResponse(backendResponse, Context);
-                }
-                catch (Exception ex)
-                {
-                    Log.Error(ex, "An exception occured while proxying request \"{RequestId}\" to the backend", Context.Items["RequestId"] as string);
-                    return new Nancy.Responses.TextResponse(Nancy.HttpStatusCode.InternalServerError, "Backend not available");
-                }
+                var req = new HttpRequestMessage(HttpMethod.Get, proxy_url);
+
+                return DoRequest(Context, req).Result;
             };
 
             Post["/"] =
             Post["/{uri*}"] = _ =>
             {
                 var proxy_url = GetProxyUrl((string)_.uri, backendPort, Context.Request.Query);
-                var client = CreateProxyClient(Context);
                 object o_content;
                 StringContent content;
                 if (Context.Items.TryGetValue("request-body", out o_content))
                     content = new StringContent(o_content as string);
                 else
                     content = new StringContent(Context.Request.Body.AsString());
+                var req = new HttpRequestMessage(HttpMethod.Post, proxy_url);
+                req.Content = content;
 
-                try
-                {
-                    var backendResponse = client.PostAsync(proxy_url, content).Result;
-                    return CreateProxyResponse(backendResponse, Context);
-                }
-                catch
-                {
-                    return 500;
-                }
+                return DoRequest(Context, req).Result;
             };
+        }
+
+        private async Task<Response> DoRequest(NancyContext ctx, HttpRequestMessage req)
+        {
+            var client = CreateProxyClient(ctx);
+            try
+            {
+                var backendResponse = await client.SendAsync(req);
+                return CreateProxyResponse(backendResponse, ctx);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "An exception occured while proxying request \"{RequestId}\" to the backend", Context.Items["RequestId"] as string);
+                return new Nancy.Responses.TextResponse(Nancy.HttpStatusCode.InternalServerError, "{ \"message\": \"Backend not available\" }");
+            }
         }
 
         string GetProxyUrl(string path, int backendPort, Nancy.DynamicDictionary querystring)

--- a/src/compute.frontend/Proxy.cs
+++ b/src/compute.frontend/Proxy.cs
@@ -12,7 +12,13 @@ namespace compute.frontend
 
         public ProxyModule()
         {
-            int backendPort = Env.GetEnvironmentInt("COMPUTE_BACKEND_PORT", 8081);
+            // use a different backend port for debugging, so we don't have to reserve/unreserve ports when testing in Release
+#if DEBUG
+            int defaultBackendPort = 8082;
+#else
+            int defaultBackendPort = 8081;
+#endif
+            int backendPort = Env.GetEnvironmentInt("COMPUTE_BACKEND_PORT", defaultBackendPort);
 
             Get["/_debug"] = _ => "Hello World!"; // test frontend
 

--- a/src/compute.geometry/Program.cs
+++ b/src/compute.geometry/Program.cs
@@ -30,7 +30,13 @@ namespace compute.geometry
             Logging.Init();
             LogVersions();
 
-            int backendPort = Env.GetEnvironmentInt("COMPUTE_BACKEND_PORT", 8081);
+            // use a different backend port for debugging, so we don't have to reserve/unreserve ports when testing in Release
+#if DEBUG
+            int defaultBackendPort = 8082;
+#else
+            int defaultBackendPort = 8081;
+#endif
+            int backendPort = Env.GetEnvironmentInt("COMPUTE_BACKEND_PORT", defaultBackendPort);
 
             Topshelf.HostFactory.Run(x =>
             {


### PR DESCRIPTION
The `api_token` header wasn't allowed. While I was in there I fixed a bug where proxy (POST) errors looked like CORS issues.