### PR TITLE
Replace Nancy self-host with OWIN

### DIFF
--- a/src/compute.frontend/Proxy.cs
+++ b/src/compute.frontend/Proxy.cs
@@ -14,13 +14,7 @@ namespace compute.frontend
 
         public ProxyModule()
         {
-            // use a different backend port for debugging, so we don't have to reserve/unreserve ports when testing in Release
-#if DEBUG
-            int defaultBackendPort = 8082;
-#else
-            int defaultBackendPort = 8081;
-#endif
-            int backendPort = Env.GetEnvironmentInt("COMPUTE_BACKEND_PORT", defaultBackendPort);
+            int backendPort = Env.GetEnvironmentInt("COMPUTE_BACKEND_PORT", 8081);
 
             Get["/_debug"] = _ => "Hello World!"; // test frontend
 

--- a/src/compute.geometry/Bootstrapper.cs
+++ b/src/compute.geometry/Bootstrapper.cs
@@ -14,9 +14,6 @@ namespace compute.geometry
 
         protected override void ApplicationStartup(TinyIoCContainer container, IPipelines pipelines)
         {
-            Log.Information("Launching RhinoCore library as {User}", Environment.UserName);
-            Program.RhinoCore = new Rhino.Runtime.InProcess.RhinoCore(null, Rhino.Runtime.InProcess.WindowStyle.NoWindow);
-
             // Load GH at startup so it can get initialized on the main thread
             var pluginObject = Rhino.RhinoApp.GetPlugInObject("Grasshopper");
             var runheadless = pluginObject?.GetType().GetMethod("RunHeadless");

--- a/src/compute.geometry/Bootstrapper.cs
+++ b/src/compute.geometry/Bootstrapper.cs
@@ -28,7 +28,7 @@ namespace compute.geometry
                 loadComputePlugsin.Invoke(null, null);
 
             Nancy.StaticConfiguration.DisableErrorTraces = false;
-            pipelines.OnError += (ctx, ex) => LogError(ctx, ex);
+            pipelines.OnError += LogError;
             ApiKey.Initialize(pipelines);
 
 
@@ -60,8 +60,12 @@ namespace compute.geometry
 
         private static dynamic LogError(NancyContext ctx, Exception ex)
         {
-            string id = ctx.Request.Headers["X-Compute-Id"].FirstOrDefault();
-            Log.Error(ex, "An exception occured while processing request \"{RequestId}\"", id);
+            string id = ctx.Request.Headers["X-Compute-Id"].FirstOrDefault(); // set by frontend
+            var msg = "An exception occured while processing request";
+            if (id != null)
+                Log.Error(ex, msg + " \"{RequestId}\"", id);
+            else
+                Log.Error(ex, msg);
             return null;
         }
     }

--- a/src/compute.geometry/Bootstrapper.cs
+++ b/src/compute.geometry/Bootstrapper.cs
@@ -25,9 +25,9 @@ namespace compute.geometry
                 loadComputePlugsin.Invoke(null, null);
 
             Nancy.StaticConfiguration.DisableErrorTraces = false;
+
             pipelines.OnError += LogError;
             ApiKey.Initialize(pipelines);
-
 
             Rhino.Runtime.HostUtils.RegisterComputeEndpoint("grasshopper", typeof(Endpoints.GrasshopperEndpoint));
 

--- a/src/compute.geometry/Bootstrapper.cs
+++ b/src/compute.geometry/Bootstrapper.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Linq;
+using Nancy;
+using Nancy.Bootstrapper;
+using Nancy.Conventions;
+using Nancy.TinyIoc;
+using Serilog;
+
+namespace compute.geometry
+{
+    public class Bootstrapper : Nancy.DefaultNancyBootstrapper
+    {
+        private byte[] _favicon;
+
+        protected override void ApplicationStartup(TinyIoCContainer container, IPipelines pipelines)
+        {
+            Log.Information("Launching RhinoCore library as {User}", Environment.UserName);
+            Program.RhinoCore = new Rhino.Runtime.InProcess.RhinoCore(null, Rhino.Runtime.InProcess.WindowStyle.NoWindow);
+
+            // Load GH at startup so it can get initialized on the main thread
+            var pluginObject = Rhino.RhinoApp.GetPlugInObject("Grasshopper");
+            var runheadless = pluginObject?.GetType().GetMethod("RunHeadless");
+            if (runheadless != null)
+                runheadless.Invoke(pluginObject, null);
+
+            var loadComputePlugsin = typeof(Rhino.PlugIns.PlugIn).GetMethod("LoadComputeExtensionPlugins");
+            if (loadComputePlugsin != null)
+                loadComputePlugsin.Invoke(null, null);
+
+            Nancy.StaticConfiguration.DisableErrorTraces = false;
+            pipelines.OnError += (ctx, ex) => LogError(ctx, ex);
+            ApiKey.Initialize(pipelines);
+
+
+            Rhino.Runtime.HostUtils.RegisterComputeEndpoint("grasshopper", typeof(Endpoints.GrasshopperEndpoint));
+
+            base.ApplicationStartup(container, pipelines);
+        }
+
+        protected override void ConfigureConventions(NancyConventions nancyConventions)
+        {
+            base.ConfigureConventions(nancyConventions);
+            nancyConventions.StaticContentsConventions.Add(StaticContentConventionBuilder.AddDirectory("docs"));
+        }
+
+        protected override byte[] FavIcon
+        {
+            get { return _favicon ?? (_favicon = LoadFavIcon()); }
+        }
+
+        private byte[] LoadFavIcon()
+        {
+            using (var resourceStream = GetType().Assembly.GetManifestResourceStream("compute.geometry.favicon.ico"))
+            {
+                var memoryStream = new System.IO.MemoryStream();
+                resourceStream.CopyTo(memoryStream);
+                return memoryStream.GetBuffer();
+            }
+        }
+
+        private static dynamic LogError(NancyContext ctx, Exception ex)
+        {
+            string id = ctx.Request.Headers["X-Compute-Id"].FirstOrDefault();
+            Log.Error(ex, "An exception occured while processing request \"{RequestId}\"", id);
+            return null;
+        }
+    }
+}

--- a/src/compute.geometry/Logging.cs
+++ b/src/compute.geometry/Logging.cs
@@ -28,8 +28,8 @@ namespace compute.geometry
                 .MinimumLevel.Debug()
 #endif
                 .Enrich.FromLogContext()
-                .Enrich.WithProperty("Source", "geometry")
-                .WriteTo.Console(outputTemplate: "{Timestamp:o} {Level:w3}: {Source} {Message:lj} {Properties:j}{NewLine}{Exception}")
+                //.Enrich.WithProperty("Source", "geometry")
+                .WriteTo.Console()
                 .WriteTo.File(new JsonFormatter(), path, rollingInterval: RollingInterval.Day, retainedFileCountLimit: limit);
 
             var cloudwatch_enabled = false;

--- a/src/compute.geometry/Program.cs
+++ b/src/compute.geometry/Program.cs
@@ -1,14 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
+using Microsoft.Owin.Hosting;
 using Nancy;
-using Nancy.Bootstrapper;
-using Nancy.Conventions;
-using Nancy.Extensions;
-using Nancy.Hosting.Self;
 using Nancy.Routing;
-using Nancy.TinyIoc;
 using Serilog;
 using Topshelf;
 
@@ -23,37 +20,47 @@ namespace compute.geometry
             RhinoInside.Resolver.Initialize();
 #if DEBUG
             string rhinoSystemDir = @"C:\dev\github\mcneel\rhino\src4\bin\Debug";
-            if (System.IO.Directory.Exists(rhinoSystemDir))
+            if (File.Exists(rhinoSystemDir + "\\Rhino.exe"))
                 RhinoInside.Resolver.RhinoSystemDirectory = rhinoSystemDir;
 #endif
 
             Logging.Init();
             LogVersions();
 
-            // use a different backend port for debugging, so we don't have to reserve/unreserve ports when testing in Release
-#if DEBUG
-            int defaultBackendPort = 8082;
-#else
-            int defaultBackendPort = 8081;
-#endif
-            int backendPort = Env.GetEnvironmentInt("COMPUTE_BACKEND_PORT", defaultBackendPort);
+            int port = Env.GetEnvironmentInt("COMPUTE_BACKEND_PORT", 8081);
 
-            Topshelf.HostFactory.Run(x =>
+            //            Topshelf.HostFactory.Run(x =>
+            //            {
+            //                x.UseSerilog();
+            //                x.ApplyCommandLine();
+            //                x.SetStartTimeout(new TimeSpan(0, 1, 0));
+            //                x.Service<NancySelfHost>(s =>
+            //                  {
+            //                      s.ConstructUsing(name => new NancySelfHost());
+            //                      s.WhenStarted(tc => tc.Start(port));
+            //                      s.WhenStopped(tc => tc.Stop());
+            //                  });
+            //                x.RunAsPrompt();
+            //                //x.RunAsLocalService();
+            //                x.SetDisplayName("compute.geometry");
+            //                x.SetServiceName("compute.geometry");
+            //            });
+
+            var url = $"http://localhost:{port}";
+
+            StartOptions options = new StartOptions(url);
+
+            // disable built-in owin tracing by using a null traceoutput
+            options.Settings.Add(
+                typeof(Microsoft.Owin.Hosting.Tracing.ITraceOutputFactory).FullName,
+                typeof(NullTraceOutputFactory).AssemblyQualifiedName);
+
+            //using (WebApp.Start<Startup>(url))
+            using (WebApp.Start<Startup>(options))
             {
-                x.UseSerilog();
-                x.ApplyCommandLine();
-                x.SetStartTimeout(new TimeSpan(0, 1, 0));
-                x.Service<NancySelfHost>(s =>
-                  {
-                      s.ConstructUsing(name => new NancySelfHost());
-                      s.WhenStarted(tc => tc.Start(backendPort));
-                      s.WhenStopped(tc => tc.Stop());
-                  });
-                x.RunAsPrompt();
-                //x.RunAsLocalService();
-                x.SetDisplayName("compute.geometry");
-                x.SetServiceName("compute.geometry");
-            });
+                Log.Information("Running on {Url}", url);
+                Console.ReadLine();
+            }
 
             if (RhinoCore != null)
                 RhinoCore.Dispose();
@@ -72,121 +79,11 @@ namespace compute.geometry
         }
     }
 
-    public class NancySelfHost
+    public class NullTraceOutputFactory : Microsoft.Owin.Hosting.Tracing.ITraceOutputFactory
     {
-        private NancyHost _nancyHost;
-        private System.Diagnostics.Process _backendProcess = null;
-
-        public void Start(int http_port)
+        public TextWriter Create(string outputFile)
         {
-            Log.Information("Launching RhinoCore library as {User}", Environment.UserName);
-            Program.RhinoCore = new Rhino.Runtime.InProcess.RhinoCore(null, Rhino.Runtime.InProcess.WindowStyle.NoWindow);
-            var config = new HostConfiguration();
-#if DEBUG
-            config.RewriteLocalhost = false;  // Don't require URL registration since geometry service always runs on localhost
-#endif
-            var listenUriList = new List<Uri>();
-
-            if (http_port > 0)
-                listenUriList.Add(new Uri($"http://localhost:{http_port}"));
-
-            if (listenUriList.Count > 0)
-                _nancyHost = new NancyHost(config, listenUriList.ToArray());
-            else
-                Log.Error("Neither COMPUTE_HTTP_PORT nor COMPUTE_HTTPS_PORT are set. Not listening!");
-            try
-            {
-                _nancyHost.Start();
-                foreach (var uri in listenUriList)
-                    Log.Information("compute.geometry running on {Uri}", uri.OriginalString);
-            }
-            catch (AutomaticUrlReservationCreationFailureException)
-            {
-                Log.Error(GetAutomaticUrlReservationCreationFailureExceptionMessage(listenUriList));
-                Environment.Exit(1);
-            }
-        }
-
-        // TODO: move this somewhere else
-        string GetAutomaticUrlReservationCreationFailureExceptionMessage(List<Uri> listenUriList)
-        {
-            var msg = new StringBuilder();
-            msg.AppendLine("Url not reserved. From an elevated command promt, run:");
-            msg.AppendLine();
-            foreach (var uri in listenUriList)
-                msg.AppendLine($"netsh http add urlacl url=\"{uri.Scheme}://+:{uri.Port}/\" user=\"Everyone\"");
-            return msg.ToString();
-        }
-
-        public void Stop()
-        {
-            if (_backendProcess != null)
-                _backendProcess.Kill();
-            _nancyHost.Stop();
-        }
-    }
-
-    public class Bootstrapper : Nancy.DefaultNancyBootstrapper
-    {
-        private byte[] _favicon;
-
-        protected override void ApplicationStartup(TinyIoCContainer container, IPipelines pipelines)
-        {
-            Log.Debug("ApplicationStartup");
-
-            // Load GH at startup so it can get initialized on the main thread
-            var pluginObject = Rhino.RhinoApp.GetPlugInObject("Grasshopper");
-            var runheadless = pluginObject?.GetType().GetMethod("RunHeadless");
-            if (runheadless != null)
-                runheadless.Invoke(pluginObject, null);
-
-            var loadComputePlugsin = typeof(Rhino.PlugIns.PlugIn).GetMethod("LoadComputeExtensionPlugins");
-            if (loadComputePlugsin != null)
-                loadComputePlugsin.Invoke(null, null);
-
-            Nancy.StaticConfiguration.DisableErrorTraces = false;
-            pipelines.OnError += (ctx, ex) => LogError(ctx, ex);
-            pipelines.AfterRequest += AddCORSSupport;
-            ApiKey.Initialize(pipelines);
-
-
-            Rhino.Runtime.HostUtils.RegisterComputeEndpoint("grasshopper", typeof(Endpoints.GrasshopperEndpoint));
-
-            base.ApplicationStartup(container, pipelines);
-        }
-
-        private static void AddCORSSupport(NancyContext context)
-        {
-            context.Response.Headers.Add("Access-Control-Allow-Origin", "*");
-            context.Response.Headers.Add("Access-Control-Allow-Methods", "OPTIONS,POST,GET,HEAD");
-            context.Response.Headers.Add("Access-Control-Allow-Headers", "Authorization,Origin,Accept,Content-Type,User-Agent,Access-Control-Allow-Headers,Access-Control-Request-Method,Access-Control-Request-Headers");
-        }
-        protected override void ConfigureConventions(NancyConventions nancyConventions)
-        {
-            base.ConfigureConventions(nancyConventions);
-            nancyConventions.StaticContentsConventions.Add(StaticContentConventionBuilder.AddDirectory("docs"));
-        }
-
-        protected override byte[] FavIcon
-        {
-            get { return _favicon ?? (_favicon = LoadFavIcon()); }
-        }
-
-        private byte[] LoadFavIcon()
-        {
-            using (var resourceStream = GetType().Assembly.GetManifestResourceStream("compute.geometry.favicon.ico"))
-            {
-                var memoryStream = new System.IO.MemoryStream();
-                resourceStream.CopyTo(memoryStream);
-                return memoryStream.GetBuffer();
-            }
-        }
-
-        private static dynamic LogError(NancyContext ctx, Exception ex)
-        {
-            string id = ctx.Request.Headers["X-Compute-Id"].FirstOrDefault();
-            Log.Error(ex, "An exception occured while processing request \"{RequestId}\"", id);
-            return null;
+            return StreamWriter.Null;
         }
     }
 

--- a/src/compute.geometry/Startup.cs
+++ b/src/compute.geometry/Startup.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Owin;
+using Microsoft.Owin.Cors;
+using Owin;
+
+[assembly: OwinStartup(typeof(compute.geometry.Startup))]
+
+namespace compute.geometry
+{
+    public class Startup
+    {
+        public void Configuration(IAppBuilder app)
+        {
+            app.UseCors(CorsOptions.AllowAll);
+            app.Use<LoggingMiddleware>();
+            app.UseNancy();
+        }
+    }
+
+    /// <summary>
+    /// Custom request logging for debugging.
+    /// </summary>
+    internal class LoggingMiddleware : OwinMiddleware
+    {
+        public LoggingMiddleware(OwinMiddleware next)
+            : base(next)
+        {
+        }
+
+        public override async Task Invoke(IOwinContext ctx)
+        {
+            IOwinRequest req = ctx.Request;
+
+            // invoke the next middleware in the pipeline
+            await Next.Invoke(ctx);
+
+            IOwinResponse res = ctx.Response;
+            string contentLength = res.ContentLength > -1 ? res.ContentLength.ToString() : "-";
+
+            // log request in apache format
+            string msg = $"{req.RemoteIpAddress} - [{DateTime.Now:o}] \"{req.Method} {req.Uri.AbsolutePath} {req.Protocol}\" {res.StatusCode} {contentLength}";
+            Console.WriteLine(msg);
+        }
+    }
+}

--- a/src/compute.geometry/compute.geometry.csproj
+++ b/src/compute.geometry/compute.geometry.csproj
@@ -49,6 +49,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ApiKey.cs" />
+    <Compile Include="Bootstrapper.cs" />
     <Compile Include="DataCache.cs" />
     <Compile Include="Endpoints\GrasshopperEndpoint.cs" />
     <Compile Include="Environment.cs" />
@@ -60,6 +61,7 @@
     <Compile Include="Logging.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Startup.cs" />
     <EmbeddedResource Include="RhinoCompute.cs" />
     <Compile Include="ResthopperEndpoints.cs" />
   </ItemGroup>
@@ -76,13 +78,22 @@
     <PackageReference Include="AWSSDK.S3">
       <Version>3.3.24</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.Owin.Cors">
+      <Version>4.0.1</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Owin.Host.HttpListener">
+      <Version>4.0.1</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Owin.Hosting">
+      <Version>4.0.1</Version>
+    </PackageReference>
     <PackageReference Include="Nancy">
       <Version>1.4.4</Version>
     </PackageReference>
     <PackageReference Include="Nancy.Gzip">
       <Version>0.1.0</Version>
     </PackageReference>
-    <PackageReference Include="Nancy.Hosting.Self">
+    <PackageReference Include="Nancy.Owin">
       <Version>1.4.1</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">


### PR DESCRIPTION
Adopting OWIN (or Katana, Microsoft's OWIN implementation) will enable us to build a web application that can run either as a console executable _or_ under IIS. So far I've done the first part by replacing Nancy.Hosting.Self with OWIN.

* Wraps Nancy with OWIN, self-host only for now
* Handles CORS in the OWIN middleware – far, _far_ more straightforward than trying to do this consistently in Nancy (successful requests, unhandled exceptions and 404s all follow slightly different paths in Nancy)
* Also uses OWIN to add simple request logging which will make developing applications on top of compute more transparent
* Adds the environment variable `COMPUTE_BIND_URLS` (name up for discussion) as a way to specify which protocols, interfaces and ports to listen on, e.g. `$env:COMPUTE_BIND_URLS="http://+:80;https://+443"` (modelled after [`DOTNET_URLS`](https://andrewlock.net/5-ways-to-set-the-urls-for-an-aspnetcore-app/#environment-variables))
* To existing users, there's no change in behaviour

The next step will be to refactor everything except Program.cs into a class library. Adding the Microsoft.Owin.Host.SystemWeb package is all that's needed to host the application in IIS. See my [sample project](https://github.com/pearswj/sample-owin-nancy) for an example.