### PR TITLE
Remove compute.frontend project from compute.sln

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,25 +3,23 @@ version: '{build}'
 environment:
   AWS_DEFAULT_REGION: us-east-1
 
-# build
-image: Visual Studio 2017
-configuration: Release
-before_build:
-  - nuget restore src\compute.sln
-  - ps: (get-content .\src\compute.geometry\FixedEndpoints.cs).replace('git_sha = null', 'git_sha = "' + ${env:APPVEYOR_REPO_COMMIT}.Substring(0, 8) + '"') | set-content .\src\compute.geometry\FixedEndpoints.cs
-build:
-  project: src\compute.sln
-  verbosity: minimal
-
 # patch assembly info
 assembly_info:
   patch: true
   file: '**\AssemblyInfo.cs'
   assembly_version: '1.0.0.{version}'
 
+# build
+image: Visual Studio 2019
+before_build:
+  - ps: (get-content .\src\compute.geometry\FixedEndpoints.cs).replace('git_sha = null', 'git_sha = "' + ${env:APPVEYOR_REPO_COMMIT}.Substring(0, 8) + '"') | set-content .\src\compute.geometry\FixedEndpoints.cs
+build_script:
+  - msbuild src\compute.sln -restore -p:Configuration=Release -v:minimal -logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+  - 7z a -tzip -r compute.zip %APPVEYOR_BUILD_FOLDER%\src\bin\Release\*
+  - msbuild src\compute.frontend -restore -p:Configuration=Release -v:minimal -logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+
 # package artifacts and create codedeploy app revision
 after_build:
-  - 7z a -tzip -r compute.zip %APPVEYOR_BUILD_FOLDER%\src\bin\Release\*
   - ps: |
       md dist\src\bin
       cp -r src\bin\Release dist\src\bin\

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,19 @@
+# What's in here?
+
+#### compute.geometry
+
+The main geometry server project. This is probably what you're looking for.
+
+#### compute.client
+
+Generates clients for the server.
+
+---
+
+#### compute.frontend
+
+⚠️ Ignore this project.
+
+The original _compute_ project got a bit bloated with request logging and authentication methods, so we split it into _geometry_ and _frontend_. It's used on compute.rhino3d.com and that's it.
+
+If you want something to put in front of a compute server, check out the [Rhino Compute AppServer](https://github.com/mcneel/compute.rhino3d.appserver).

--- a/src/compute.frontend/compute.frontend.csproj
+++ b/src/compute.frontend/compute.frontend.csproj
@@ -3,7 +3,7 @@
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
     <ProjectGuid>{5AE28138-B0A2-40C1-B62C-67CC7371E992}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <RootNamespace>compute.frontend</RootNamespace>

--- a/src/compute.geometry/compute.geometry.csproj
+++ b/src/compute.geometry/compute.geometry.csproj
@@ -3,7 +3,7 @@
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
     <ProjectGuid>{01757ED0-58C4-47DA-926A-70ACD31B93E1}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <RootNamespace>compute.geometry</RootNamespace>

--- a/src/compute.geometry/compute.geometry.csproj
+++ b/src/compute.geometry/compute.geometry.csproj
@@ -73,9 +73,6 @@
     <EmbeddedResource Include="favicon.ico" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3">
-      <Version>3.3.24</Version>
-    </PackageReference>
     <PackageReference Include="Microsoft.Owin.Cors">
       <Version>4.0.1</Version>
     </PackageReference>

--- a/src/compute.sln
+++ b/src/compute.sln
@@ -1,11 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2010
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30413.136
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "compute.geometry", "compute.geometry\compute.geometry.csproj", "{01757ED0-58C4-47DA-926A-70ACD31B93E1}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "compute.frontend", "compute.frontend\compute.frontend.csproj", "{5AE28138-B0A2-40C1-B62C-67CC7371E992}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -17,10 +15,6 @@ Global
 		{01757ED0-58C4-47DA-926A-70ACD31B93E1}.Debug|x64.Build.0 = Debug|x64
 		{01757ED0-58C4-47DA-926A-70ACD31B93E1}.Release|x64.ActiveCfg = Release|x64
 		{01757ED0-58C4-47DA-926A-70ACD31B93E1}.Release|x64.Build.0 = Release|x64
-		{5AE28138-B0A2-40C1-B62C-67CC7371E992}.Debug|x64.ActiveCfg = Debug|x64
-		{5AE28138-B0A2-40C1-B62C-67CC7371E992}.Debug|x64.Build.0 = Debug|x64
-		{5AE28138-B0A2-40C1-B62C-67CC7371E992}.Release|x64.ActiveCfg = Release|x64
-		{5AE28138-B0A2-40C1-B62C-67CC7371E992}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
The compute.frontend project is used solely on compute.rhino3d.com and causes confusion when getting compute set up.

The recommended way to use compute is to run compute.geometry and put something like the [AppServer](https://github.com/mcneel/compute.rhino3d.appserver) in front of it to control access and implement use-case specific behaviour like caching.