### PR TITLE
Add api key option to python and .net client generators

### DIFF
--- a/src/compute.client/PythonClient.cs
+++ b/src/compute.client/PythonClient.cs
@@ -75,6 +75,7 @@ __version__ = '{Version}'
 
 url = 'https://compute.rhino3d.com/'
 authToken = ''
+apiKey = ''
 stopat = 0
 
 
@@ -85,6 +86,7 @@ def ComputeFetch(endpoint, arglist):
                 return o.Encode()
             return json.JSONEncoder.default(self, o)
     global authToken
+    global apiKey
     global url
     global stopat
     posturl = url + endpoint
@@ -93,10 +95,11 @@ def ComputeFetch(endpoint, arglist):
         else: posturl += '?stopat='
         posturl += str(stopat)
     postdata = json.dumps(arglist, cls=__Rhino3dmEncoder)
-    headers = {{
-        'Authorization': 'Bearer ' + authToken,
-        'User-Agent': 'compute.rhino3d.py/' + __version__
-    }}
+    headers = {{ 'User-Agent': 'compute.rhino3d.py/' + __version__ }}
+    if authToken:
+        headers['Authorization'] = 'Bearer ' + authToken
+    if apiKey:
+        headers['RhinoComputeKey'] = apiKey
     r = requests.post(posturl, data=postdata, headers=headers)
     return r.json()
 
@@ -130,7 +133,7 @@ def DecodeToCommonObject(item):
     if item is None:
         return None
     if isinstance(item, list):
-        return [rhino3dm.CommonObject.Decode(x) for x in item]
+        return [DecodeToCommonObject(x) for x in item]
     return rhino3dm.CommonObject.Decode(item)
 
 

--- a/src/compute.client/RhinoComputeHeader.cs
+++ b/src/compute.client/RhinoComputeHeader.cs
@@ -14,6 +14,7 @@ namespace Rhino.Compute
     {
         public static string WebAddress { get; set; } = "https://compute.rhino3d.com";
         public static string AuthToken { get; set; }
+        public static string ApiKey { get; set; }
         public static string Version => "{{VERSION}}";
 
         public static T Post<T>(string function, params object[] postData)
@@ -23,8 +24,8 @@ namespace Rhino.Compute
 
         public static T PostWithConverter<T>(string function, JsonConverter converter, params object[] postData)
         {
-            if (string.IsNullOrWhiteSpace(AuthToken))
-                throw new UnauthorizedAccessException("AuthToken must be set");
+            if (string.IsNullOrWhiteSpace(AuthToken) && WebAddress.Equals("https://compute.rhino3d.com"))
+                throw new UnauthorizedAccessException("AuthToken must be set for compute.rhino3d.com");
 
             for( int i=0; i<postData.Length; i++ )
             {
@@ -40,21 +41,7 @@ namespace Rhino.Compute
             string json = converter == null ?
                 JsonConvert.SerializeObject(postData, Formatting.None) :
                 JsonConvert.SerializeObject(postData, Formatting.None, converter);
-            if (!function.StartsWith("/"))
-                function = "/" + function;
-            string uri = (WebAddress + function).ToLower();
-            var request = (System.Net.HttpWebRequest)System.Net.WebRequest.Create(uri);
-            request.ContentType = "application/json";
-            request.Headers.Add("Authorization", "Bearer " + AuthToken);
-            request.UserAgent = "compute.rhino3d.cs/" + Version;
-            request.Method = "POST";
-            using (var streamWriter = new StreamWriter(request.GetRequestStream()))
-            {
-                streamWriter.Write(json);
-                streamWriter.Flush();
-            }
-
-            var response = request.GetResponse();
+            var response = DoPost(function, json);
             using (var streamReader = new StreamReader(response.GetResponseStream()))
             {
                 var result = streamReader.ReadToEnd();
@@ -66,23 +53,11 @@ namespace Rhino.Compute
 
         public static T0 Post<T0, T1>(string function, out T1 out1, params object[] postData)
         {
-            if (string.IsNullOrWhiteSpace(AuthToken))
-                throw new UnauthorizedAccessException("AuthToken must be set");
-            string json = Newtonsoft.Json.JsonConvert.SerializeObject(postData);
-            if (!function.StartsWith("/"))
-                function = "/" + function;
-            string uri = (WebAddress + function).ToLower();
-            var request = System.Net.WebRequest.Create(uri);
-            request.ContentType = "application/json";
-            request.Headers.Add("Authorization", "Bearer " + AuthToken);
-            request.Method = "POST";
-            using (var streamWriter = new StreamWriter(request.GetRequestStream()))
-            {
-                streamWriter.Write(json);
-                streamWriter.Flush();
-            }
+            if (string.IsNullOrWhiteSpace(AuthToken) && WebAddress.Equals("https://compute.rhino3d.com"))
+                throw new UnauthorizedAccessException("AuthToken must be set for compute.rhino3d.com");
 
-            var response = request.GetResponse();
+            string json = Newtonsoft.Json.JsonConvert.SerializeObject(postData);
+            var response = DoPost(function, json);
             using (var streamReader = new StreamReader(response.GetResponseStream()))
             {
                 var jsonString = streamReader.ReadToEnd();
@@ -95,23 +70,11 @@ namespace Rhino.Compute
 
         public static T0 Post<T0, T1, T2>(string function, out T1 out1, out T2 out2, params object[] postData)
         {
-            if (string.IsNullOrWhiteSpace(AuthToken))
-                throw new UnauthorizedAccessException("AuthToken must be set");
-            string json = Newtonsoft.Json.JsonConvert.SerializeObject(postData);
-            if (!function.StartsWith("/"))
-                function = "/" + function;
-            string uri = (WebAddress + function).ToLower();
-            var request = System.Net.WebRequest.Create(uri);
-            request.ContentType = "application/json";
-            request.Headers.Add("Authorization", "Bearer " + AuthToken);
-            request.Method = "POST";
-            using (var streamWriter = new StreamWriter(request.GetRequestStream()))
-            {
-                streamWriter.Write(json);
-                streamWriter.Flush();
-            }
+            if (string.IsNullOrWhiteSpace(AuthToken) && WebAddress.Equals("https://compute.rhino3d.com"))
+                throw new UnauthorizedAccessException("AuthToken must be set for compute.rhino3d.com");
 
-            var response = request.GetResponse();
+            string json = Newtonsoft.Json.JsonConvert.SerializeObject(postData);
+            var response = DoPost(function, json);
             using (var streamReader = new StreamReader(response.GetResponseStream()))
             {
                 var jsonString = streamReader.ReadToEnd();
@@ -121,6 +84,36 @@ namespace Rhino.Compute
                 out2 = ja[2].ToObject<T2>();
                 return ja[0].ToObject<T0>();
             }
+        }
+
+        // run all requests through here
+        private static System.Net.WebResponse DoPost(string function, string json)
+        {
+
+            if (!function.StartsWith("/")) // add leading /
+                function = "/" + function; // if not present
+
+            string uri = $"{WebAddress}{function}".ToLower();
+            var request = (System.Net.HttpWebRequest)System.Net.WebRequest.Create(uri);
+            request.ContentType = "application/json";
+            request.UserAgent = $"compute.rhino3d.cs/{Version}";
+            request.Method = "POST";
+
+            // try auth token (compute.rhino3d.com only)
+            if (!string.IsNullOrWhiteSpace(AuthToken))
+                request.Headers.Add("Authorization", "Bearer " + AuthToken);
+
+            // try api key (self-hosted compute)
+            if (!string.IsNullOrWhiteSpace(ApiKey))
+                request.Headers.Add("RhinoComputeKey", ApiKey);
+            
+            using (var streamWriter = new StreamWriter(request.GetRequestStream()))
+            {
+                streamWriter.Write(json);
+                streamWriter.Flush();
+            }
+
+            return request.GetResponse();
         }
 
         public static string ApiAddress(Type t, string function)


### PR DESCRIPTION
Allows the python and .net Compute clients to work with self-hosted Compute servers that have `RHINO_COMPUTE_KEY` configured