### PR TITLE
Solve entire grasshopper definition at once and log errors better

### DIFF
--- a/src/compute.geometry/Config.cs
+++ b/src/compute.geometry/Config.cs
@@ -32,6 +32,11 @@ namespace compute.geometry
         public static string[] GetDeprecationWarnings() => _warnings.ToArray();
 
         /// <summary>
+        /// RHINO_COMPUTE_DEBUG: enables debug logging (defaults to true in DEBUG).
+        /// </summary>
+        public static bool Debug { get; private set; }
+
+        /// <summary>
         /// Loads config from environment variables (or uses defaults).
         /// </summary>
         public static void Load()
@@ -40,6 +45,11 @@ namespace compute.geometry
             ApiKey = GetEnvironmentVariable<string>(RHINO_COMPUTE_KEY, null);
             LogPath = GetEnvironmentVariable(RHINO_COMPUTE_LOG_PATH, Path.Combine(Path.GetTempPath(), "Compute", "Logs"), COMPUTE_LOG_PATH);
             LogRetainDays = GetEnvironmentVariable(RHINO_COMPUTE_LOG_RETAIN_DAYS, 10, COMPUTE_LOG_RETAIN_DAYS);
+
+#if DEBUG
+            Debug = true;
+#endif
+            Debug = GetEnvironmentVariable(RHINO_COMPUTE_DEBUG, Debug);
 
             foreach (var name in _ignored)
             {
@@ -55,6 +65,7 @@ namespace compute.geometry
         const string RHINO_COMPUTE_KEY = "RHINO_COMPUTE_KEY";
         const string RHINO_COMPUTE_LOG_PATH = "RHINO_COMPUTE_LOG_PATH";
         const string RHINO_COMPUTE_LOG_RETAIN_DAYS = "RHINO_COMPUTE_LOG_RETAIN_DAYS";
+        const string RHINO_COMPUTE_DEBUG = "RHINO_COMPUTE_DEBUG";
 
         // deprecated
         const string COMPUTE_BIND_URLS = "COMPUTE_BIND_URLS";

--- a/src/compute.geometry/GrasshopperDefinition.cs
+++ b/src/compute.geometry/GrasshopperDefinition.cs
@@ -413,7 +413,7 @@ namespace compute.geometry
 
             // solve definition
             Definition.Enabled = true;
-            Definition.NewSolution(true, GH_SolutionMode.CommandLine);
+            Definition.NewSolution(false, GH_SolutionMode.CommandLine);
 
             LogRuntimeMessages(Definition.ActiveObjects());
 

--- a/src/compute.geometry/GrasshopperDefinition.cs
+++ b/src/compute.geometry/GrasshopperDefinition.cs
@@ -551,18 +551,18 @@ namespace compute.geometry
             {
                 foreach (var msg in obj.RuntimeMessages(GH_RuntimeMessageLevel.Error))
                 {
-                    Log.Error("Error in grasshopper component: \"{NickName}\" ({Id}): {Message}", obj.NickName, obj.InstanceGuid, msg);
+                    Log.Error($"Error in grasshopper component: \"{obj.NickName}\" ({obj.InstanceGuid}): {msg}");
                     HasErrors = true;
                 }
                 if (Config.Debug)
                 {
                     foreach (var msg in obj.RuntimeMessages(GH_RuntimeMessageLevel.Warning))
                     {
-                        Log.Debug("Warning in grasshopper component: \"{NickName}\" ({Id}): {Message}", obj.NickName, obj.InstanceGuid, msg);
+                        Log.Debug($"Warning in grasshopper component: \"{obj.NickName}\" ({obj.InstanceGuid}): {msg}");
                     }
                     foreach (var msg in obj.RuntimeMessages(GH_RuntimeMessageLevel.Remark))
                     {
-                        Log.Debug("Remark in grasshopper component: \"{NickName}\" ({Id}): {Message}", obj.NickName, obj.InstanceGuid, msg);
+                        Log.Debug($"Remark in grasshopper component: \"{obj.NickName}\" ({obj.InstanceGuid}): {msg}");
                     }
                 }
             }

--- a/src/compute.geometry/GrasshopperDefinition.cs
+++ b/src/compute.geometry/GrasshopperDefinition.cs
@@ -409,22 +409,15 @@ namespace compute.geometry
             Schema outputSchema = new Schema();
             outputSchema.Algo = "";
 
-            foreach(var kvp in _output)
+            // solve definition
+            Definition.Enabled = true;
+            Definition.NewSolution(true, GH_SolutionMode.CommandLine);
+
+            foreach (var kvp in _output)
             {
                 var param = kvp.Value;
                 if (param == null)
                     continue;
-                try
-                {
-                    param.CollectData();
-                    param.ComputeData();
-                }
-                catch (Exception)
-                {
-                    param.Phase = GH_SolutionPhase.Failed;
-                    // TODO: throw something better
-                    throw;
-                }
 
                 // Get data
                 var outputTree = new DataTree<ResthopperObject>();

--- a/src/compute.geometry/Logging.cs
+++ b/src/compute.geometry/Logging.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using Serilog;
+using Serilog.Events;
 using Serilog.Formatting.Json;
 
 namespace compute.geometry
@@ -9,6 +10,9 @@ namespace compute.geometry
     {
         static bool _enabled = false;
 
+        /// <summary>
+        /// Initialises globally-shared logger.
+        /// </summary>
         public static void Init()
         {
             if (_enabled)
@@ -16,11 +20,10 @@ namespace compute.geometry
 
             var path = Path.Combine(Config.LogPath, "log-geometry-.txt"); // log-geometry-20180925.txt, etc.
             var limit = Config.LogRetainDays;
+            var level = Config.Debug ? LogEventLevel.Debug : LogEventLevel.Information;
 
             var logger = new LoggerConfiguration()
-#if DEBUG
-                .MinimumLevel.Debug()
-#endif
+                .MinimumLevel.Is(level)
                 .Enrich.FromLogContext()
                 //.Enrich.WithProperty("Source", "geometry")
                 .WriteTo.Console()

--- a/src/compute.geometry/Logging.cs
+++ b/src/compute.geometry/Logging.cs
@@ -27,7 +27,7 @@ namespace compute.geometry
                 .Enrich.FromLogContext()
                 //.Enrich.WithProperty("Source", "geometry")
                 .WriteTo.Console()
-                .WriteTo.File(new JsonFormatter(), path, rollingInterval: RollingInterval.Day, retainedFileCountLimit: limit);
+                .WriteTo.File(new JsonFormatter(renderMessage: true), path, rollingInterval: RollingInterval.Day, retainedFileCountLimit: limit);
 
             Log.Logger = logger.CreateLogger();
 

--- a/src/compute.geometry/Logging.cs
+++ b/src/compute.geometry/Logging.cs
@@ -39,5 +39,19 @@ namespace compute.geometry
 
             _enabled = true;
         }
+
+        internal static void LogExceptionData(System.Exception ex)
+        {
+            //if (!Config.Debug)
+            //    return;
+            if (ex?.Data != null)
+            {
+                // TODO: skip useless keys once we figure out what those are
+                foreach (var key in ex.Data.Keys)
+                {
+                    Log.Debug($"{key} : {{Data}}", ex.Data[key]);
+                }
+            }
+        }
     }
 }

--- a/src/compute.geometry/Program.cs
+++ b/src/compute.geometry/Program.cs
@@ -81,7 +81,8 @@ namespace compute.geometry
 
             Rhino.Runtime.HostUtils.OnExceptionReport += (source, ex) => {
                 Log.Error(ex, "An exception occured while processing request");
-                LogExceptionData(ex); // debug only
+                if (Config.Debug)
+                    Logging.LogExceptionData(ex);
             };
 
             StartOptions options = new StartOptions();
@@ -108,19 +109,6 @@ namespace compute.geometry
             }
 
             Log.Information("Listening on {Urls}", _bind);
-        }
-
-        private void LogExceptionData(Exception ex)
-        {
-            if (!Config.Debug)
-                return;
-            if (ex?.Data != null)
-            {
-                foreach (var key in ex.Data.Keys)
-                {
-                    Log.Debug("{Key} : {Value}", key, ex.Data[key]);
-                }
-            }
         }
 
         public void Stop()

--- a/src/compute.geometry/Program.cs
+++ b/src/compute.geometry/Program.cs
@@ -46,6 +46,8 @@ namespace compute.geometry
 
             if (RhinoCore != null)
                 RhinoCore.Dispose();
+
+            Log.CloseAndFlush();
         }
 
         private static void LogVersions()
@@ -79,6 +81,7 @@ namespace compute.geometry
 
             Rhino.Runtime.HostUtils.OnExceptionReport += (source, ex) => {
                 Log.Error(ex, "An exception occured while processing request");
+                LogExceptionData(ex); // debug only
             };
 
             StartOptions options = new StartOptions();
@@ -105,6 +108,19 @@ namespace compute.geometry
             }
 
             Log.Information("Listening on {Urls}", _bind);
+        }
+
+        private void LogExceptionData(Exception ex)
+        {
+            if (!Config.Debug)
+                return;
+            if (ex?.Data != null)
+            {
+                foreach (var key in ex.Data.Keys)
+                {
+                    Log.Debug("{Key} : {Value}", key, ex.Data[key]);
+                }
+            }
         }
 
         public void Stop()

--- a/src/compute.geometry/ResthopperEndpoints.cs
+++ b/src/compute.geometry/ResthopperEndpoints.cs
@@ -82,6 +82,8 @@ namespace compute.geometry
             Response res = returnJson;
             res.ContentType = "application/json";
             res = res.WithHeader("Server-Timing", $"decode;dur={decodeTime}, solve;dur={solveTime}, encode;dur={encodeTime}");
+            if (definition.HasErrors)
+                res.StatusCode = Nancy.HttpStatusCode.InternalServerError;
             return res;
         }
 


### PR DESCRIPTION
This is the result of some work to get Compute to play nicer with Ladybug Tools. It includes a different method of solving the Grasshopper definition and more logging to get insight into what might be going wrong with a definition that isn't behaving on Compute.

* Grasshopper definition solved in one go instead of as needed per output (#118)
* Logs errors from Grasshopper components' `RuntimeMessages` (#107)
* Returns HTTP 500 if there were any errors in the definition (doesn't affect the body)
* Control debug logging with `RHINO_COMPUTE_DEBUG=true` (default when running `Debug` configuration)
* Adds more debug logging...
    * `Data` property of exceptions reported by RhinoCommon
    * Warnings and remarks in `RuntimeMessages`

![image](https://user-images.githubusercontent.com/121068/98555689-253d1480-229a-11eb-9d8e-586860802936.png)
