### PR TITLE
Fix multiple in py3 client

### DIFF
--- a/src/compute.client/PythonClient.cs
+++ b/src/compute.client/PythonClient.cs
@@ -61,6 +61,10 @@ namespace computegen
             get
             {
                 return @"from . import Util
+try:
+    from itertools import izip as zip # python 2
+except ImportError:
+    pass # python 3
 
 ";
             }
@@ -401,7 +405,7 @@ def DecodeToLine(item):
                 if (parameters.Count == 1)
                     sb.AppendLine($"{T1}if multiple: args = [[item] for item in {parameters[0]}]");
                 else
-                    sb.AppendLine($"{T1}if multiple: args = zip({paramList.ToString()})");
+                    sb.AppendLine($"{T1}if multiple: args = list(zip({paramList}))");
 
                 string endpoint = method.Identifier.ToString();
                 sb.AppendLine($"{T1}response = Util.ComputeFetch(url, args)");


### PR DESCRIPTION
Changes the behaviour of `zip()` in Python 2 to use `izip()` and return an iterator as in Python 3. The iterator is then converted to a `list`.

Fixes COMPUTE-71