### PR TITLE
Fire document added event when setting up definition

### DIFF
--- a/src/compute.geometry/GrasshopperDefinition.cs
+++ b/src/compute.geometry/GrasshopperDefinition.cs
@@ -59,6 +59,9 @@ namespace compute.geometry
             if (!archive.ExtractObject(definition, "Definition"))
                 throw new Exception("Unable to extract definition from archive");
 
+            // raise DocumentServer.DocumentAdded event (used by some plug-ins)
+            Grasshopper.Instances.DocumentServer.AddDocument(definition);
+
             GrasshopperDefinition rc = new GrasshopperDefinition(definition);
             foreach( var obj in definition.Objects)
             {


### PR DESCRIPTION
Add definition to `DocumentServer` to raise `DocumentAdded` event. This event is used by some plug-ins as a way to register handlers for `GH_Document` events when the doc is loaded.

Primarily this is being added to support plug-ins which interact with `SolutionStart` and `SolutionEnd` to do multi-stage solves.

This overload of `AddDocument` is very basic and I haven't seen anything weird so far...!