### PR TITLE
Add explicit endpoints for overloads with no params

### DIFF
--- a/src/compute.geometry/GeometryEndPoint.cs
+++ b/src/compute.geometry/GeometryEndPoint.cs
@@ -198,9 +198,7 @@ namespace compute.geometry
 
                 foreach (var overload in overloads)
                 {
-                    var parameters = overload.GetParameters();
-                    if (parameters == null || parameters.Length < 1)
-                        continue;
+                    // generate explicit endpoints for all overloads, even if there are no parameters (see #142)
                     endpoints.Add(new GeometryEndPoint(t, overload));
                 }
 


### PR DESCRIPTION
The python and javascript clients assume that RhinoCommon methods with no params have their own explicit endpoint, i.e. `/rhino/geometry/curve/duplicatesegments-curve` (#142).

I can't see any negative effects of adding a few more endpoints and this matches the pattern used for methods which have parameters.

```shell
/namespace/type/method
/namespace/type/method-type             # <-- NEW
/namespace/type/method-type_arg1_arg2
```

For reference, explicit endpoints were originally added in #3.