### PR TITLE
Auto launch compute when needed by Hops

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ before_build:
   - ps: (get-content .\src\compute.geometry\FixedEndpoints.cs).replace('git_sha = null', 'git_sha = "' + ${env:APPVEYOR_REPO_COMMIT}.Substring(0, 8) + '"') | set-content .\src\compute.geometry\FixedEndpoints.cs
 build_script:
   - msbuild src\compute.sln -restore -p:Configuration=Release -v:minimal -logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
-  - 7z a -tzip -r compute.zip %APPVEYOR_BUILD_FOLDER%\src\compute.geometry\bin\Release\compute\*
+  - 7z a -tzip -r compute.zip %APPVEYOR_BUILD_FOLDER%\src\compute.geometry\bin\Release\*
   - msbuild src\compute.frontend -restore -p:Configuration=Release -v:minimal -logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 
 # package artifacts and create codedeploy app revision

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ before_build:
   - ps: (get-content .\src\compute.geometry\FixedEndpoints.cs).replace('git_sha = null', 'git_sha = "' + ${env:APPVEYOR_REPO_COMMIT}.Substring(0, 8) + '"') | set-content .\src\compute.geometry\FixedEndpoints.cs
 build_script:
   - msbuild src\compute.sln -restore -p:Configuration=Release -v:minimal -logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
-  - 7z a -tzip -r compute.zip %APPVEYOR_BUILD_FOLDER%\src\bin\Release\*
+  - 7z a -tzip -r compute.zip %APPVEYOR_BUILD_FOLDER%\src\bin\Release\compute\*
   - msbuild src\compute.frontend -restore -p:Configuration=Release -v:minimal -logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 
 # package artifacts and create codedeploy app revision

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ before_build:
   - ps: (get-content .\src\compute.geometry\FixedEndpoints.cs).replace('git_sha = null', 'git_sha = "' + ${env:APPVEYOR_REPO_COMMIT}.Substring(0, 8) + '"') | set-content .\src\compute.geometry\FixedEndpoints.cs
 build_script:
   - msbuild src\compute.sln -restore -p:Configuration=Release -v:minimal -logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
-  - 7z a -tzip -r compute.zip %APPVEYOR_BUILD_FOLDER%\src\bin\Release\compute\*
+  - 7z a -tzip -r compute.zip %APPVEYOR_BUILD_FOLDER%\src\compute.geometry\bin\Release\compute\*
   - msbuild src\compute.frontend -restore -p:Configuration=Release -v:minimal -logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 
 # package artifacts and create codedeploy app revision

--- a/src/compute.components/Hops.csproj
+++ b/src/compute.components/Hops.csproj
@@ -15,29 +15,31 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <TargetFrameworkProfile />
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\</OutputPath>
+    <OutputPath>..\bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisIgnoreBuiltInRules>false</CodeAnalysisIgnoreBuiltInRules>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\</OutputPath>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>..\bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug - McNeel Core|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug - McNeel Core|x64'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\</OutputPath>
+    <OutputPath>..\bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x64</PlatformTarget>
     <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
@@ -45,7 +47,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json.Rhino">
-      <HintPath>..\..\..\..\..\..\Program Files\Rhino 7\System\Newtonsoft.Json.Rhino.dll</HintPath>
+      <HintPath>C:\Program Files\Rhino 7\System\Newtonsoft.Json.Rhino.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
@@ -99,8 +101,8 @@ Erase "$(TargetPath)"</PostBuildEvent>
   <PropertyGroup>
     <FallbackCulture>en-US</FallbackCulture>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
-    <StartProgram>C:\Program Files\Rhino WIP\System\Rhino.exe</StartProgram>
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <StartProgram>C:\Program Files\Rhino 7\System\Rhino.exe</StartProgram>
     <StartArguments>
     </StartArguments>
     <StartAction>Program</StartAction>

--- a/src/compute.components/Hops.sln
+++ b/src/compute.components/Hops.sln
@@ -4,20 +4,31 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 16.0.30611.23
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hops", "Hops.csproj", "{82CB7266-A8BC-4D3E-99F6-B91504C7117F}"
+	ProjectSection(ProjectDependencies) = postProject
+		{3E0229A6-3417-48C1-8297-6F7622F80037} = {3E0229A6-3417-48C1-8297-6F7622F80037}
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "compute.geometry", "..\compute.geometry\compute.geometry.csproj", "{3E0229A6-3417-48C1-8297-6F7622F80037}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug - McNeel Core|Any CPU = Debug - McNeel Core|Any CPU
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
+		Debug - McNeel Core|x64 = Debug - McNeel Core|x64
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{82CB7266-A8BC-4D3E-99F6-B91504C7117F}.Debug - McNeel Core|Any CPU.ActiveCfg = Debug - McNeel Core|Any CPU
-		{82CB7266-A8BC-4D3E-99F6-B91504C7117F}.Debug - McNeel Core|Any CPU.Build.0 = Debug - McNeel Core|Any CPU
-		{82CB7266-A8BC-4D3E-99F6-B91504C7117F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{82CB7266-A8BC-4D3E-99F6-B91504C7117F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{82CB7266-A8BC-4D3E-99F6-B91504C7117F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{82CB7266-A8BC-4D3E-99F6-B91504C7117F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{82CB7266-A8BC-4D3E-99F6-B91504C7117F}.Debug - McNeel Core|x64.ActiveCfg = Debug - McNeel Core|x64
+		{82CB7266-A8BC-4D3E-99F6-B91504C7117F}.Debug - McNeel Core|x64.Build.0 = Debug - McNeel Core|x64
+		{82CB7266-A8BC-4D3E-99F6-B91504C7117F}.Debug|x64.ActiveCfg = Debug|x64
+		{82CB7266-A8BC-4D3E-99F6-B91504C7117F}.Debug|x64.Build.0 = Debug|x64
+		{82CB7266-A8BC-4D3E-99F6-B91504C7117F}.Release|x64.ActiveCfg = Release|x64
+		{82CB7266-A8BC-4D3E-99F6-B91504C7117F}.Release|x64.Build.0 = Release|x64
+		{3E0229A6-3417-48C1-8297-6F7622F80037}.Debug - McNeel Core|x64.ActiveCfg = Debug|x64
+		{3E0229A6-3417-48C1-8297-6F7622F80037}.Debug - McNeel Core|x64.Build.0 = Debug|x64
+		{3E0229A6-3417-48C1-8297-6F7622F80037}.Debug|x64.ActiveCfg = Debug|x64
+		{3E0229A6-3417-48C1-8297-6F7622F80037}.Debug|x64.Build.0 = Debug|x64
+		{3E0229A6-3417-48C1-8297-6F7622F80037}.Release|x64.ActiveCfg = Release|x64
+		{3E0229A6-3417-48C1-8297-6F7622F80037}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/compute.geometry/compute.geometry.csproj
+++ b/src/compute.geometry/compute.geometry.csproj
@@ -6,13 +6,15 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <Copyright>Copyright © 2017-2021 Robert McNeel " Associates. All Rights Reserved.</Copyright>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <OutputPath>..\bin\$(Configuration)</OutputPath>
+    <Platforms>x64</Platforms>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <DefineConstants>TRACE;DEBUG;COMPUTE_CORE</DefineConstants>
+    <OutputPath>..\bin\Debug\compute\</OutputPath>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <DefineConstants>TRACE;COMPUTE_CORE</DefineConstants>
+    <OutputPath>..\bin\Release\compute\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="favicon.ico" />


### PR DESCRIPTION
Part of #164

When path references a local file, try to launch a compute server on the same computer. For now, the compute server launches in a full console window so we can watch what is actually happening.