### PR TITLE
Don't give sliders a custom name

### DIFF
--- a/src/compute.geometry/GrasshopperDefinition.cs
+++ b/src/compute.geometry/GrasshopperDefinition.cs
@@ -787,10 +787,6 @@ namespace compute.geometry
             {
                 return "Geometry";
             }
-            if (param is GH_NumberSlider)
-            {
-                return "Slider"; // differentiate from "Number"
-            }
             return param.TypeName;
         }
 


### PR DESCRIPTION
It messes with hops' input param parsing and it isn't really necessary - we can infer from the presence of min/max values instead.