### PR TITLE
Add basic skeleton for new parent compute.rhino3d.exe app

### DIFF
--- a/src/compute.rhino3d/Program.cs
+++ b/src/compute.rhino3d/Program.cs
@@ -1,0 +1,17 @@
+namespace compute.rhino3d
+{
+    using Microsoft.AspNetCore.Hosting;
+    using Microsoft.Extensions.Hosting;
+
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            var host = Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder => webBuilder.UseStartup<Startup>())
+                .Build();
+
+            host.Run();
+        }
+    }
+}

--- a/src/compute.rhino3d/Proxy.cs
+++ b/src/compute.rhino3d/Proxy.cs
@@ -1,0 +1,109 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace compute.rhino3d
+{
+    public class ProxyModule : Carter.CarterModule
+    {
+        HttpClient _client;
+
+        public ProxyModule()
+        {
+            _client = new HttpClient(new HttpClientHandler { AllowAutoRedirect = false });
+            _client.DefaultRequestHeaders.Add("User-Agent", $"compute.rhino3d-proxy/1.0.0");
+
+
+            Get("/healthcheck", async (req, res) => await res.WriteAsync("healthy"));
+            Get("/robots.txt", async (req, res) => await res.WriteAsync("User-agent: *\nDisallow: / "));
+            Get("/", async (req, res) => await res.WriteAsync("compute.rhino3d"));
+            Get("/{uri}", ProxyGetHandler);
+            Post("/grasshopper", PostGrasshopperHandler);
+            Post("/{uri}", PostHandler);
+        }
+
+        private async Task ProxyGetHandler(HttpRequest req, HttpResponse res)
+        {
+            //string url = ComputeChildren.GetComputeServerBaseUrl();
+            //_client.SendAsync(req);
+
+            await res.WriteAsync("GET " + req.Path);
+        }
+
+        private async Task PostHandler(HttpRequest req, HttpResponse res)
+        {
+            await res.WriteAsync("POST " + req.Path);
+        }
+
+        private async Task PostGrasshopperHandler(HttpRequest req, HttpResponse res)
+        {
+            await res.WriteAsync("POST grasshopper " + req.Path);
+        }
+
+        private readonly string[] _skipHeaders = new string[]
+        {
+            "Host",         // causes 400 invalid host
+            "User-Agent",   // occasionally throws System.FormatException
+            "Authorization" // frontend only
+        };
+
+        //private async Task<Response> DoRequest(NancyContext ctx, HttpRequestMessage req)
+        //{
+        //    // proxy headers
+        //    foreach (var header in ctx.Request.Headers)
+        //    {
+        //        if (_skipHeaders.Contains(header.Key, StringComparer.OrdinalIgnoreCase) ||
+        //            header.Key.ToLower().StartsWith("content")) // content headers handled below
+        //            continue;
+
+        //        if (!req.Headers.TryAddWithoutValidation(header.Key, header.Value))
+        //            Log.Warning($"Couldn't pass header '{header.Key}: {header.Value}' to backend");
+        //    }
+
+        //    if (req.Content != null)
+        //    {
+        //        if (MediaTypeHeaderValue.TryParse(ctx.Request.Headers.ContentType, out var contentType))
+        //            req.Content.Headers.ContentType = contentType;
+        //        else
+        //        {
+        //            Log.Warning($"Couldn't pass invalid Content-Type '{ctx.Request.Headers.ContentType}' to backend");
+        //            req.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+        //        }
+        //        req.Content.Headers.ContentLength = ctx.Request.Headers.ContentLength;
+        //    }
+
+        //    // add compute-specific headers
+        //    req.Headers.Add("X-Compute-Id", Context.Items["RequestId"] as string);
+        //    req.Headers.Add("X-Compute-Host", Context.Items["Hostname"] as string);
+
+        //    try
+        //    {
+        //        var backendResponse = await _client.SendAsync(req);
+        //        return CreateProxyResponse(backendResponse, ctx);
+        //    }
+        //    catch (Exception ex)
+        //    {
+        //        Log.Error(ex, "An exception occured while proxying request \"{RequestId}\" to the backend", Context.Items["RequestId"] as string);
+        //        return new Nancy.Responses.TextResponse(Nancy.HttpStatusCode.InternalServerError, "{ \"message\": \"Backend not available\" }");
+        //    }
+        //}
+
+        //Nancy.Response CreateProxyResponse(HttpResponseMessage backendResponse, Nancy.NancyContext context)
+        //{
+        //    string responseBody = backendResponse.Content.ReadAsStringAsync().Result;
+        //    var response = (Nancy.Response)responseBody;
+        //    response.StatusCode = (Nancy.HttpStatusCode)backendResponse.StatusCode;
+        //    foreach (var header in backendResponse.Headers)
+        //    {
+        //        foreach (var value in header.Value)
+        //            response.Headers.Add(header.Key, value);
+        //    }
+        //    foreach (var header in backendResponse.Content.Headers)
+        //    {
+        //        foreach (var value in header.Value)
+        //            response.Headers.Add(header.Key, value);
+        //    }
+        //    return response;
+        //}
+    }
+}

--- a/src/compute.rhino3d/Startup.cs
+++ b/src/compute.rhino3d/Startup.cs
@@ -1,0 +1,21 @@
+namespace compute.rhino3d
+{
+    using Carter;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.Extensions.DependencyInjection;
+
+    public class Startup
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddCarter();
+        }
+
+        public void Configure(IApplicationBuilder app)
+        {
+            app.UseRouting();
+
+            app.UseEndpoints(builder => builder.MapCarter());
+        }
+    }
+}

--- a/src/compute.rhino3d/compute.rhino3d.csproj
+++ b/src/compute.rhino3d/compute.rhino3d.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <AssemblyName>compute.rhino3d</AssemblyName>
+    <OutputType>Exe</OutputType>
+    <Platforms>x64</Platforms>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <OutputPath>..\bin\Debug</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutputPath>..\bin\Release</OutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Carter" Version="5.2.0" />
+  </ItemGroup>
+</Project>

--- a/src/compute.sln
+++ b/src/compute.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 16.0.30413.136
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "compute.geometry", "compute.geometry\compute.geometry.csproj", "{01757ED0-58C4-47DA-926A-70ACD31B93E1}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "compute.rhino3d", "compute.rhino3d\compute.rhino3d.csproj", "{CC91F57C-9A5D-42C8-9D87-3A229A62BCBA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -15,6 +17,10 @@ Global
 		{01757ED0-58C4-47DA-926A-70ACD31B93E1}.Debug|x64.Build.0 = Debug|x64
 		{01757ED0-58C4-47DA-926A-70ACD31B93E1}.Release|x64.ActiveCfg = Release|x64
 		{01757ED0-58C4-47DA-926A-70ACD31B93E1}.Release|x64.Build.0 = Release|x64
+		{CC91F57C-9A5D-42C8-9D87-3A229A62BCBA}.Debug|x64.ActiveCfg = Debug|x64
+		{CC91F57C-9A5D-42C8-9D87-3A229A62BCBA}.Debug|x64.Build.0 = Debug|x64
+		{CC91F57C-9A5D-42C8-9D87-3A229A62BCBA}.Release|x64.ActiveCfg = Release|x64
+		{CC91F57C-9A5D-42C8-9D87-3A229A62BCBA}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
First step for child process architecture #148 

Parent application is called compute.rhino3d.exe and is aa ASP.NET Core 5 application.

Not working yet, just getting the initial bare bones project committed.

Using Carter for now as it is very similar to NancyFX. Looks like it should be easy to remove this dependency in the future if we feel the need and as we learn more about writing ASP.NET Core