### PR TITLE
fix path using os.path.join where hosts have tailing slashes 

### DIFF
--- a/src/compute.client/PythonClient.cs
+++ b/src/compute.client/PythonClient.cs
@@ -73,6 +73,7 @@ except ImportError:
         readonly string UtilModuleContents =
 $@"import rhino3dm
 import json
+import os
 import requests
 
 __version__ = '{Version}'
@@ -93,7 +94,7 @@ def ComputeFetch(endpoint, arglist):
     global apiKey
     global url
     global stopat
-    posturl = url + endpoint
+    posturl = os.path.join(url, endpoint)
     if(stopat>0):
         if(posturl.find('?')>0): posturl += '&stopat='
         else: posturl += '?stopat='


### PR DESCRIPTION
This can cause the compute server to throw an error for an invalid url.

The client should responsible for sending the correct path, some webservers that might sit on top of compute server might deal with the doubel slash situation making this error difficult to debug for people setting up their own compute server.