### PR TITLE
switch to new form of ShowModal for Mac

### DIFF
--- a/src/compute.components/HopsComponent.cs
+++ b/src/compute.components/HopsComponent.cs
@@ -225,9 +225,8 @@ namespace Compute.Components
 
         void ShowSetDefinitionUi()
         {
-            var parent = Rhino.UI.Runtime.PlatformServiceProvider.Service.GetEtoWindow(Grasshopper.Instances.DocumentEditor.Handle);
             var form = new SetDefinitionForm(RemoteDefinitionLocation);
-            if(form.ShowModal(parent))
+            if(form.ShowModal(Grasshopper.Instances.EtoDocumentEditor))
             {
                 var comp = Grasshopper.Instances.ComponentServer.FindObjectByName(form.Path, true, true);
                 if (comp != null)

--- a/src/compute.components/Properties/AssemblyInfo.cs
+++ b/src/compute.components/Properties/AssemblyInfo.cs
@@ -28,7 +28,7 @@ namespace Compute.Components
             TheAssemblyInfo = this;
         }
 
-        public const string AppVersion = "0.3.3.0";
+        public const string AppVersion = "0.3.4.0";
         
         public override Bitmap Icon
         {

--- a/src/compute.geometry/GrasshopperDefinition.cs
+++ b/src/compute.geometry/GrasshopperDefinition.cs
@@ -70,6 +70,8 @@ namespace compute.geometry
 
         public static GrasshopperDefinition FromUrl(string url, bool cache)
         {
+            if (string.IsNullOrWhiteSpace(url))
+                return null;
             GrasshopperDefinition rc = DataCache.GetCachedDefinition(url);
 
             if (rc != null)
@@ -128,7 +130,7 @@ namespace compute.geometry
                 byte[] hashBytes = md5.ComputeHash(inputBytes);
 
                 // Convert the byte array to hexadecimal string
-                var sb = new System.Text.StringBuilder();
+                var sb = new System.Text.StringBuilder("md5_");
                 for (int i = 0; i < hashBytes.Length; i++)
                 {
                     sb.Append(hashBytes[i].ToString("X2"));


### PR DESCRIPTION
also prefix hash with md5 so internal code doesn't accidentally think it is a GUID