### PR TITLE
Set output as list if only one branch

### DIFF
--- a/src/hops/RemoteDefinition.cs
+++ b/src/hops/RemoteDefinition.cs
@@ -328,6 +328,8 @@ namespace Compute.Components
                 }
                 if (structure.DataCount == 1)
                     DA.SetData(paramIndex, singleGoo);
+                else if (structure.PathCount == 1)
+                    DA.SetDataList(paramIndex, structure.AllData(false)); // let grasshopper handle paths
                 else
                     DA.SetDataTree(paramIndex, structure);
             }


### PR DESCRIPTION
Let Grasshopper figure out the branch structure, instead of setting it explicitly

Fixes #275