### PR TITLE
Migrate hops.csproj to sdk-style and update dist script

### DIFF
--- a/src/build_hops_dist.py
+++ b/src/build_hops_dist.py
@@ -16,6 +16,7 @@ build_cmd = 'dotnet publish .\\hops.sln'
 build_cmd += ' -c Release'
 build_cmd += ' -p:PublishTrimmed=true'
 build_cmd += ' --self-contained true'
+build_cmd += ' -r win-x64'
 rv = os.system(build_cmd)
 if (rv != 0): sys.exit(rv)
 

--- a/src/build_hops_dist.py
+++ b/src/build_hops_dist.py
@@ -1,53 +1,26 @@
 # Build yak packages for publishing
 import os
 import shutil
+import sys
 
-dist_directory = 'dist'
-if not os.path.exists(dist_directory):
-    os.mkdir(dist_directory)
+src_dir = os.path.dirname(os.path.realpath(__file__))
+dist_dir = os.path.join(src_dir, 'dist')
 
-# build hops.gha
-build_cmd = 'msbuild .\\hops\\hops.csproj -t:restore'
-os.system(build_cmd) #nuget restore
-build_cmd = 'msbuild .\\hops\\hops.csproj'
-build_cmd += ' -p:Configuration=Release'
-build_cmd += ' -p:Platform=x64'
-build_cmd += f' -p:OutputPath="..\\{dist_directory}"'
-os.system(build_cmd)
+# clear output dir
+if os.path.exists(dist_dir):
+    shutil.rmtree(dist_dir)
 
-# build compute.geometry.exe
-build_cmd = 'msbuild .\\compute.geometry\\compute.geometry.csproj -t:restore'
-os.system(build_cmd) #nuget restore
-build_cmd = 'msbuild .\\compute.geometry\\compute.geometry.csproj'
-build_cmd += ' -p:Configuration=Release'
-build_cmd += ' -p:Platform=x64'
-build_cmd += f' -p:OutputPath="..\\{dist_directory}\\compute.geometry"'
-os.system(build_cmd)
-
-# build rhino.compute.exe
-build_cmd = 'dotnet publish .\\rhino.compute\\rhino.compute.csproj'
+# build hops (inc. self-contained rhino.compute.exe)
+os.chdir(src_dir)
+build_cmd = 'dotnet publish .\\hops.sln'
 build_cmd += ' -c Release'
-build_cmd += f' -o ".\\{dist_directory}\\rhino.compute"'
 build_cmd += ' -p:PublishTrimmed=true'
-build_cmd += ' -r win-x64'
 build_cmd += ' --self-contained true'
-os.system(build_cmd)
-
-# write manifest for yak
-manifest_content = """---
-name: Hops
-version: $version
-authors:
-- Robert McNeel & Associates
-description: Out of process definition solving using Rhino Compute
-url: https://github.com/mcneel/compute.rhino3d
-icon_url: https://raw.githubusercontent.com/mcneel/compute.rhino3d/master/src/hops/resources/Hops_48x48.png
-"""
-with open(f'{dist_directory}\\manifest.yml', 'w') as text_file:
-    text_file.write(manifest_content)
+rv = os.system(build_cmd)
+if (rv != 0): sys.exit(rv)
 
 # build yak package
-os.chdir(dist_directory)
+os.chdir(dist_dir)
 os.system('"C:\\Program Files\\Rhino 7\\System\\Yak.exe" build')
 # make V8 version as well
 for file in os.listdir('.'):

--- a/src/compute.geometry/compute.geometry.csproj
+++ b/src/compute.geometry/compute.geometry.csproj
@@ -10,11 +10,12 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <DefineConstants>TRACE;DEBUG;COMPUTE_CORE</DefineConstants>
-    <OutputPath>..\bin\Debug\compute.geometry\</OutputPath>
+    <OutputPath>..\bin\Debug\$(AssemblyName)\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <DefineConstants>TRACE;COMPUTE_CORE</DefineConstants>
-    <OutputPath>..\bin\Release\compute.geometry\</OutputPath>
+    <OutputPath>..\bin\Release\$(AssemblyName)\</OutputPath>
+    <PublishDir>..\dist\$(AssemblyName)</PublishDir>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="RhinoCompute.cs" />

--- a/src/hops/Hops.csproj
+++ b/src/hops/Hops.csproj
@@ -15,6 +15,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>..\bin\Release\</OutputPath>
+    <PublishDir>..\dist\</PublishDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug - McNeel Core|x64'">
     <DebugSymbols>true</DebugSymbols>

--- a/src/hops/Hops.csproj
+++ b/src/hops/Hops.csproj
@@ -59,6 +59,11 @@
   <ItemGroup>
     <EmbeddedResource Include="resources\Hops_48x48.png" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="manifest.yml" Condition="'$(Configuration)' == 'Release'">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <PropertyGroup>
     <FallbackCulture>en-US</FallbackCulture>
   </PropertyGroup>

--- a/src/hops/Hops.csproj
+++ b/src/hops/Hops.csproj
@@ -1,65 +1,37 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{82CB7266-A8BC-4D3E-99F6-B91504C7117F}</ProjectGuid>
+    <TargetFramework>net48</TargetFramework>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Hops</RootNamespace>
-    <AssemblyName>Hops</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <IsWebBootstrapper>false</IsWebBootstrapper>
-    <TargetFrameworkProfile />
+    <Platforms>x64</Platforms>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <UseWindowsForms>true</UseWindowsForms>
+    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
+    <TargetExt>.gha</TargetExt>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
-    <DebugSymbols>true</DebugSymbols>
     <OutputPath>..\bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <DebugType>full</DebugType>
-    <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
-    <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisIgnoreBuiltInRules>false</CodeAnalysisIgnoreBuiltInRules>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>..\bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
-    <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug - McNeel Core|x64'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>..\bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <DebugType>full</DebugType>
-    <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
-    <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisIgnoreBuiltInRules>false</CodeAnalysisIgnoreBuiltInRules>
   </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Runtime.Caching" />
+    <Reference Include="System.Web" />
+  </ItemGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json.Rhino">
       <HintPath>refs\Newtonsoft.Json.Rhino.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Runtime.Caching" />
-    <Reference Include="System.Web" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\compute.geometry\IO\GhPath.cs">
@@ -68,20 +40,9 @@
     <Compile Include="..\compute.geometry\IO\Schema.cs">
       <Link>Schema.cs</Link>
     </Compile>
-    <Compile Include="GrasshopperDefinition.cs" />
-    <Compile Include="HopsAppSettings.cs" />
-    <Compile Include="HopsAppSettingsUserControl.cs">
+    <Compile Update="HopsAppSettingsUserControl.cs">
       <SubType>UserControl</SubType>
     </Compile>
-    <Compile Include="HopsAppSettingsUserControl.Designer.cs">
-      <DependentUpon>HopsAppSettingsUserControl.cs</DependentUpon>
-    </Compile>
-    <Compile Include="MemoryCache.cs" />
-    <Compile Include="Servers.cs" />
-    <Compile Include="RemoteDefinition.cs" />
-    <Compile Include="HopsComponent.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="SetDefinitionForm.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Grasshopper">
@@ -90,9 +51,6 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="HopsAppSettingsUserControl.resx">
-      <DependentUpon>HopsAppSettingsUserControl.cs</DependentUpon>
-    </EmbeddedResource>
     <EmbeddedResource Include="resources\ComputeLogo_24x24.png" />
   </ItemGroup>
   <ItemGroup>
@@ -101,25 +59,12 @@
   <ItemGroup>
     <EmbeddedResource Include="resources\Hops_48x48.png" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
-  <PropertyGroup>
-    <PostBuildEvent>Copy "$(TargetPath)" "$(TargetDir)$(ProjectName).gha"
-Erase "$(TargetPath)"</PostBuildEvent>
-  </PropertyGroup>
   <PropertyGroup>
     <FallbackCulture>en-US</FallbackCulture>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <StartProgram>C:\Program Files\Rhino 7\System\Rhino.exe</StartProgram>
-    <StartArguments>
-    </StartArguments>
+    <StartArguments></StartArguments>
     <StartAction>Program</StartAction>
   </PropertyGroup>
 </Project>

--- a/src/hops/manifest.yml
+++ b/src/hops/manifest.yml
@@ -1,0 +1,8 @@
+---
+name: Hops
+version: $version
+authors:
+- Robert McNeel & Associates
+description: Out of process definition solving using Rhino Compute
+url: https://github.com/mcneel/compute.rhino3d
+icon_url: https://raw.githubusercontent.com/mcneel/compute.rhino3d/master/src/hops/resources/Hops_48x48.png

--- a/src/rhino.compute/rhino.compute.csproj
+++ b/src/rhino.compute/rhino.compute.csproj
@@ -4,14 +4,18 @@
     <AssemblyName>rhino.compute</AssemblyName>
     <OutputType>Exe</OutputType>
     <Platforms>x64</Platforms>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutputPath>..\bin\Debug</OutputPath>
+    <OutputPath>..\bin\Debug\$(AssemblyName)</OutputPath>
     <DefineConstants>TRACE;RHINO_COMPUTE</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <OutputPath>..\bin\Release</OutputPath>
+    <OutputPath>..\bin\Release\$(AssemblyName)</OutputPath>
     <DefineConstants>TRACE;RHINO_COMPUTE</DefineConstants>
+    <PublishDir>..\dist\$(AssemblyName)</PublishDir>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/rhino.compute/rhino.compute.csproj
+++ b/src/rhino.compute/rhino.compute.csproj
@@ -4,9 +4,7 @@
     <AssemblyName>rhino.compute</AssemblyName>
     <OutputType>Exe</OutputType>
     <Platforms>x64</Platforms>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <OutputPath>..\bin\Debug\$(AssemblyName)</OutputPath>


### PR DESCRIPTION
* Updates hops csproj format to support new `dotnet` tooling
* Simplifies the publishing script, by using `dotnet publish` on hops.sln and adding `PublishDir` to each csproj
* Adds manifest.yml to source control