### PR TITLE
Don't copy rhino.compute.exe to root of package

### DIFF
--- a/src/hops.sln
+++ b/src/hops.sln
@@ -3,11 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30611.23
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hops", "hops\Hops.csproj", "{82CB7266-A8BC-4D3E-99F6-B91504C7117F}"
-	ProjectSection(ProjectDependencies) = postProject
-		{2A56201E-62E5-4BA9-A13D-F3E5A1D0275A} = {2A56201E-62E5-4BA9-A13D-F3E5A1D0275A}
-		{3E0229A6-3417-48C1-8297-6F7622F80037} = {3E0229A6-3417-48C1-8297-6F7622F80037}
-	EndProjectSection
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Hops", "hops\Hops.csproj", "{82CB7266-A8BC-4D3E-99F6-B91504C7117F}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "compute.geometry", "compute.geometry\compute.geometry.csproj", "{3E0229A6-3417-48C1-8297-6F7622F80037}"
 EndProject


### PR DESCRIPTION
During he Hops.csproj build the `_CopyOutOfDateSourceItemsToOutputDirectory` target was copying rhino.compute.exe and rhino.compute.runtimeconfig.json to the output directory, next to Hops.gha. Removing the build dependency on rhino.compute.csproj fixes this. These files are included in the rhino.compute directory.