### PR TITLE
Update Dockerfile to work with new compute.sln

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,11 @@
 # NOTE: use 'process' isolation to build image (otherwise rhino fails to install)
 
 ### builder image
-FROM mcr.microsoft.com/dotnet/framework/sdk:4.8 as builder
+FROM mcr.microsoft.com/dotnet/sdk:5.0 as builder
 
 # copy everything, restore nuget packages and build app
 COPY src/ ./src/
-RUN msbuild /p:Configuration=Release /restore /v:Minimal src/compute.sln
+RUN dotnet build -c Release src/compute.sln
 
 ### main image
 # tag must match windows host for build (and run, if running with process isolation)
@@ -27,7 +27,7 @@ RUN curl -fSLo dotnet-framework-installer.exe https://download.visualstudio.micr
 # NOTE: edit this if you use a different version of rhino!
 # the url below will always redirect to the latest rhino 7 (email required)
 # https://www.rhino3d.com/download/rhino-for-windows/7/latest/direct?email=EMAIL
-RUN curl -fSLo rhino_installer.exe https://files.mcneel.com/dujour/exe/20210121/rhino_en-us_7.2.21021.07001.exe `
+RUN curl -fSLo rhino_installer.exe https://files.mcneel.com/dujour/exe/20210319/rhino_en-us_7.4.21078.01001.exe `
     && .\rhino_installer.exe -package -quiet `
     && del .\rhino_installer.exe
 
@@ -35,7 +35,7 @@ RUN curl -fSLo rhino_installer.exe https://files.mcneel.com/dujour/exe/20210121/
 # RUN ""C:\Program Files\Rhino 7\System\Yak.exe"" install jswan
 
 # copy compute app to image
-COPY --from=builder ["/src/bin/Release/compute", "/app"]
+COPY --from=builder ["/src/bin/Release/compute.geometry", "/app"]
 WORKDIR /app
 
 # bind compute.geometry to port 80


### PR DESCRIPTION
* Builds `rhino.compute` using .NET 5.0, but still only uses `compute.geometry`
* Updates Rhino to 7.4