### PR TITLE
Revert "use path to definition when running local"

### DIFF
--- a/src/hops/RemoteDefinition.cs
+++ b/src/hops/RemoteDefinition.cs
@@ -165,8 +165,7 @@ namespace Hops
             {
                 string postUrl = Servers.GetDescriptionPostUrl();
                 var schema = new Schema();
-                if (Path.StartsWith("http", StringComparison.OrdinalIgnoreCase)
-                    || postUrl.IndexOf("localhost", StringComparison.OrdinalIgnoreCase)>0)
+                if (Path.StartsWith("http", StringComparison.OrdinalIgnoreCase))
                 {
                     schema.Pointer = address;
                 }


### PR DESCRIPTION
Reverts mcneel/compute.rhino3d#351

This breaks potential future caching with md5 hashes