### PR TITLE
Fix component from rebuilding on all exceptions thrown from server

### DIFF
--- a/src/hops/HopsAppSettingsUserControl.cs
+++ b/src/hops/HopsAppSettingsUserControl.cs
@@ -3,7 +3,7 @@ using System.Windows.Forms;
 
 namespace Hops
 {
-    public partial class HopsAppSettingsUserControl : UserControl
+    partial class HopsAppSettingsUserControl : UserControl
     {
         public HopsAppSettingsUserControl()
         {

--- a/src/hops/Properties/AssemblyInfo.cs
+++ b/src/hops/Properties/AssemblyInfo.cs
@@ -28,7 +28,7 @@ namespace Hops
             TheAssemblyInfo = this;
         }
 
-        public const string AppVersion = "0.6.0.0";
+        public const string AppVersion = "0.6.1.0";
 
         public override Bitmap Icon
         {

--- a/src/hops/RemoteDefinition.cs
+++ b/src/hops/RemoteDefinition.cs
@@ -351,7 +351,11 @@ namespace Hops
                 bool rebuildDefinition = (responseMessage.StatusCode == System.Net.HttpStatusCode.InternalServerError
                     && schema.Errors.Count > 0
                     && string.Equals(schema.Errors[0], "Bad inputs", StringComparison.OrdinalIgnoreCase));
-                rebuildDefinition |= schema.Values.Count != _outputParams.Count;
+                if (!rebuildDefinition)
+                {
+                    if (schema.Values.Count > 0 && schema.Values.Count != _outputParams.Count)
+                        rebuildDefinition = true;
+                }
 
                 if (rebuildDefinition)
                 {


### PR DESCRIPTION
Error messages were being thrown away. See
https://discourse.mcneel.com/t/hops-cannot-read-errors-after-0-6-0-update/125144