### PR TITLE
do not block the server when reading definition metadata

### DIFF
--- a/src/compute.geometry/ResthopperEndpoints.cs
+++ b/src/compute.geometry/ResthopperEndpoints.cs
@@ -134,23 +134,18 @@ namespace compute.geometry
                     body = body.Substring(1, body.Length - 2);
 
                 Schema input = JsonConvert.DeserializeObject<Schema>(body);
-                lock (_ghsolvelock)
+
+                // load grasshopper file
+                definition = GrasshopperDefinition.FromUrl(input.Pointer, true);
+                if (definition == null)
                 {
-                    // load grasshopper file
-                    definition = GrasshopperDefinition.FromUrl(input.Pointer, true);
-                    if (definition == null)
-                    {
-                        definition = GrasshopperDefinition.FromBase64String(input.Algo, true);
-                    }
+                    definition = GrasshopperDefinition.FromBase64String(input.Algo, true);
                 }
             }
             else
             {
                 string url = Request.Query["Pointer"].ToString();
-                lock (_ghsolvelock)
-                {
-                    definition = GrasshopperDefinition.FromUrl(url, true);
-                }
+                definition = GrasshopperDefinition.FromUrl(url, true);
             }
 
             if (definition == null)

--- a/src/hops/Properties/AssemblyInfo.cs
+++ b/src/hops/Properties/AssemblyInfo.cs
@@ -28,7 +28,7 @@ namespace Hops
             TheAssemblyInfo = this;
         }
 
-        public const string AppVersion = "0.7.0.0";
+        public const string AppVersion = "0.7.1.0";
 
         public override Bitmap Icon
         {


### PR DESCRIPTION
this was causing deadlock with nested hops calls