### PR TITLE
Catch and log exceptions in DocumentAdded event handlers

### DIFF
--- a/CHANGELOG.HOPS.md
+++ b/CHANGELOG.HOPS.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Points, lines, circles were not getting converted to geometry when input to a "Get Geometry" component
 - Improved error messages by forwarding errors from remote solved components
 - 0.7.2: attempt to fix handling different forms of input strings in compute
+- 0.7.3: handle exception in a plug-in's DocumentAdded event handler and allow request to continue
 
 ## [0.6.0] - 2021-05-30
 ### Added

--- a/src/compute.geometry/GrasshopperDefinition.cs
+++ b/src/compute.geometry/GrasshopperDefinition.cs
@@ -15,6 +15,7 @@ using GH_IO.Serialization;
 using Resthopper.IO;
 using Newtonsoft.Json;
 using System.Linq;
+using Serilog;
 
 namespace compute.geometry
 {
@@ -130,8 +131,15 @@ namespace compute.geometry
             var definition = new GH_Document();
             definition.AddObject(component, false);
 
-            // raise DocumentServer.DocumentAdded event (used by some plug-ins)
-            Grasshopper.Instances.DocumentServer.AddDocument(definition);
+            try
+            {
+                // raise DocumentServer.DocumentAdded event (used by some plug-ins)
+                Grasshopper.Instances.DocumentServer.AddDocument(definition);
+            }
+            catch (Exception e)
+            {
+                Log.Error(e, "Exception in DocumentAdded event handler");
+            }
 
             GrasshopperDefinition rc = new GrasshopperDefinition(definition, null);
             rc._singularComponent = component;
@@ -167,8 +175,15 @@ namespace compute.geometry
             if (!archive.ExtractObject(definition, "Definition"))
                 throw new Exception("Unable to extract definition from archive");
 
-            // raise DocumentServer.DocumentAdded event (used by some plug-ins)
-            Grasshopper.Instances.DocumentServer.AddDocument(definition);
+            try
+            {
+                // raise DocumentServer.DocumentAdded event (used by some plug-ins)
+                Grasshopper.Instances.DocumentServer.AddDocument(definition);
+            }
+            catch (Exception e)
+            {
+                Log.Error(e, "Exception in DocumentAdded event handler");
+            }
 
             GrasshopperDefinition rc = new GrasshopperDefinition(definition, icon);
             foreach( var obj in definition.Objects)


### PR DESCRIPTION
This will effect the behaviour of plug-ins that do not handle this event in a compute-friendly way (in hops/compute only), but at least it won't prevent it from running.