### PR TITLE
Make reverse proxy request timeout configurable

### DIFF
--- a/src/rhino.compute/Config.cs
+++ b/src/rhino.compute/Config.cs
@@ -12,17 +12,21 @@ namespace rhino.compute
         /// </summary>
         public static string ApiKey { get; private set; }
 
+        public static int ReverseProxyRequestTimeout { get; private set; }
+
         /// <summary>
         /// Loads config from environment variables (or uses defaults).
         /// </summary>
         public static void Load()
         {
             ApiKey = GetEnvironmentVariable<string>(RHINO_COMPUTE_KEY, null);
+            ReverseProxyRequestTimeout = GetEnvironmentVariable<int>(RHINO_COMPUTE_TIMEOUT, 100);
         }
 
         #region private
         // environment variables
         const string RHINO_COMPUTE_KEY = "RHINO_COMPUTE_KEY";
+        const string RHINO_COMPUTE_TIMEOUT = "RHINO_COMPUTE_TIMEOUT";
 
         readonly static List<string> _warnings = new List<string>();
 

--- a/src/rhino.compute/ReverseProxy.cs
+++ b/src/rhino.compute/ReverseProxy.cs
@@ -24,6 +24,7 @@ namespace rhino.compute
 
             _client = new HttpClient(new HttpClientHandler { AllowAutoRedirect = false });
             _client.DefaultRequestHeaders.Add("User-Agent", $"compute.rhino3d-proxy/1.0.0");
+            _client.Timeout = TimeSpan.FromSeconds(Config.ReverseProxyRequestTimeout);
 
             // Launch child processes on start. Getting the base url is enough to get things rolling
             if (ComputeChildren.SpawnOnStartup)


### PR DESCRIPTION
Adds the `RHINO_COMPUTE_TIMEOUT` environment variable for configuring the request timeout (in seconds) for the `HttpClient` used when reverse proxying requests to compute.geometry.

To test, configure the env var for the `rhino.compute` profile in launchSettings.json (see below) and try to solve [sleep.gh](https://github.com/mcneel/compute.rhino3d/files/8193121/sleep.zip) (sleeps for 10 seconds before returning).

```
 "environmentVariables": {
  "RHINO_COMPUTE_TIMEOUT": "2"
}
```

See https://discourse.mcneel.com/t/httpclient-timeout-of-100-seconds-with-rhino-compute/138952