### PR TITLE
return component name and nickname from ghhops_server

### DIFF
--- a/src/ghhops-server-py/ghhops_server/component.py
+++ b/src/ghhops-server-py/ghhops_server/component.py
@@ -42,6 +42,8 @@ class HopsComponent:
     def encode(self):
         """Serializer"""
         metadata = {
+            "Name": self.name,
+            "NickName": self.nickname,
             "Description": self.description,
             "Inputs": self.inputs,
             "Outputs": self.outputs,


### PR DESCRIPTION
Tiny suggestion.
It looks like ghhops_server doesn't include component name and nickname in the io_response metadata, and Hops component in grasshopper doesn't try updating its name and nickname from the metadata, so it just stays "Hops" for both values.
It would be nice to have both updated according to the values defined in ghhops python component.
This doesn't solve the issue completely, since the Hops component itself should also read these values and update itself from response, but this seems to be the first stept towards showing correct name and nickname in grasshopper