### PR TITLE
Specify prerelease versions for hops package

### DIFF
--- a/src/hops/Properties/AssemblyInfo.cs
+++ b/src/hops/Properties/AssemblyInfo.cs
@@ -29,6 +29,8 @@ namespace Hops
         }
 
         public const string AppVersion = "0.15.0.0";
+        
+        public const string Prerelease = ""; // empty string or prerelease identifier starting with "-" (e.g. "-dev.1")
 
         public override Bitmap Icon
         {
@@ -82,7 +84,7 @@ namespace Hops
             get
             {
                 var t = typeof(GhaAssemblyInfo).Assembly.GetName().Version;
-                return $"{t.Major}.{t.Minor}.{t.Build}";
+                return $"{t.Major}.{t.Minor}.{t.Build}{Prerelease}";
             }
         }
     }


### PR DESCRIPTION
Makes it easy to optionally specify a prerelease suffix for `GhaAssemblyInfo.AssemblyVersion`.

This version number is used by the grasshopper plug-in, which in turn is used when building the package.

@andyopayne, it could be useful to publish Hops packages publicly for testing. Marking them as prerelease versions will hide them for users that don't have "include pre-releases" checked in Rhino's package manager.