### PR TITLE
ApiKey - Script

### DIFF
--- a/script/production/module_rhino.ps1
+++ b/script/production/module_rhino.ps1
@@ -3,7 +3,7 @@
 
 param (
     [Parameter(Mandatory=$true)][string] $EmailAddress,
-    [Parameter(Mandatory=$true)][string] $ApiKey,
+    [Parameter(Mandatory=$true)][AllowEmptyString()][string] $ApiKey,
     [Parameter(Mandatory=$true)][string] $RhinoToken,
     [switch] $install = $false
 )
@@ -32,6 +32,10 @@ function SetEnvVar {
     [System.Environment]::SetEnvironmentVariable($name, $value, "Machine")
 }
 #EndRegion funcs
+
+if(!$ApiKey){
+    Write-Warning "ApiKey is not set, we recommend you to set ApiKey for production servers" -WarningAction Inquire
+}
 
 Write-Step 'Set environment variables'
 SetEnvVar 'RHINO_TOKEN' $RhinoToken -secret


### PR DESCRIPTION
Deployment script forces to write an ApiKey. If the ApiKey is not set, Rhino is not installed and the environment variables are not set but the user does not notice.
I've added the option for the ApiKey to be an empty string but also added a warning to the user if that is the case.

- Added ApiKey warning if empty
- Allow ApiKey to be empty