### PR TITLE
Add a .NET Core launcher project

### DIFF
--- a/src/HopsNetCore/HopsNetCore.csproj
+++ b/src/HopsNetCore/HopsNetCore.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\hops\Hops.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <StartProgram>C:\Program Files\Rhino 8 WIP\System\Rhino.exe</StartProgram>
+    <StartArguments></StartArguments>
+    <StartAction>Program</StartAction>
+  </PropertyGroup>
+
+</Project>

--- a/src/HopsNetCore/Program.cs
+++ b/src/HopsNetCore/Program.cs
@@ -1,0 +1,4 @@
+﻿// See https://aka.ms/new-console-template for more information
+Console.WriteLine("Hello, World!");
+
+// NOTE: This project is only used to launch Rhino using the .NET Core debugger and is never run directly

--- a/src/hops.sln
+++ b/src/hops.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "compute.geometry", "compute
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "rhino.compute", "rhino.compute\rhino.compute.csproj", "{2A56201E-62E5-4BA9-A13D-F3E5A1D0275A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HopsNetCore", "HopsNetCore\HopsNetCore.csproj", "{B07A8E4D-3101-418C-B8AD-E677BD84D78D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -27,6 +29,10 @@ Global
 		{2A56201E-62E5-4BA9-A13D-F3E5A1D0275A}.Debug|x64.Build.0 = Debug|x64
 		{2A56201E-62E5-4BA9-A13D-F3E5A1D0275A}.Release|x64.ActiveCfg = Release|x64
 		{2A56201E-62E5-4BA9-A13D-F3E5A1D0275A}.Release|x64.Build.0 = Release|x64
+		{B07A8E4D-3101-418C-B8AD-E677BD84D78D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B07A8E4D-3101-418C-B8AD-E677BD84D78D}.Debug|x64.Build.0 = Debug|Any CPU
+		{B07A8E4D-3101-418C-B8AD-E677BD84D78D}.Release|x64.ActiveCfg = Release|Any CPU
+		{B07A8E4D-3101-418C-B8AD-E677BD84D78D}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Adds a separate project to debug Rhino using the .NET Core debugger.