### PR TITLE
fix unassigned var error in update compute bootstrap script

### DIFF
--- a/script/production/module_update_compute.ps1
+++ b/script/production/module_update_compute.ps1
@@ -67,15 +67,15 @@ if ($artifactID -lt 0){
 
 $downloadurl = "$nightlyPrefix/$actionurl/$artifactID.zip"
 
-if (-Not (Test-Path -Path $appDirectory)){
-    New-Item $appDirectory -ItemType Directory
+if (-Not (Test-Path -Path $physicalPathRoot)){
+    New-Item $physicalPathRoot -ItemType Directory
 }
 
-if ((Test-Path $appDirectory)) {
+if ((Test-Path $physicalPathRoot)) {
     Write-Step "Download and unzip latest build of compute from $downloadurl"
-    Download $downloadurl "$appDirectory/compute.zip"
-    Expand-Archive "$appDirectory/compute.zip" -DestinationPath $appDirectory
-    Remove-Item "$appDirectory/compute.zip"
+    Download $downloadurl "$physicalPathRoot/compute.zip"
+    Expand-Archive "$physicalPathRoot/compute.zip" -DestinationPath $physicalPathRoot
+    Remove-Item "$physicalPathRoot/compute.zip"
 }
 
 Write-Step "Starting the IIS Service"


### PR DESCRIPTION
fix wrong var name in module_update_compute.ps1
replaced unassigned $appDirectory with $physicalPathRoot 

change was introduced in last commit 661916f56113985bebad7444ece86eae6a0e3e1b