### PR TITLE
Fix up launchsettings to debug in .NET 4.8

### DIFF
--- a/src/hops/Properties/launchSettings.json
+++ b/src/hops/Properties/launchSettings.json
@@ -2,7 +2,11 @@
   "profiles": {
     "Hops": {
       "commandName": "Executable",
-      "executablePath": "C:\\Program Files\\Rhino 8 WIP\\System\\Rhino.exe",
+      "executablePath": "C:\\Program Files\\Rhino 8\\System\\Rhino.exe",
+      "commandLineArgs": "/netfx",
+      "environmentVariables": {
+        "RHINO_PACKAGE_DIRS": "$(SolutionDir)bin\\Debug"
+      },
       "nativeDebugging": true
     }
   }


### PR DESCRIPTION
This properly enables debugging compute/hops in Visual Studio under .NET Framework.