### PR TITLE
Fixes COMPUTE-268

### DIFF
--- a/src/compute.geometry/Startup.cs
+++ b/src/compute.geometry/Startup.cs
@@ -55,21 +55,8 @@ namespace compute.geometry
 
             Rhino.RhinoApp.SendWriteToConsole = true;
 
-            // Load GH at startup so it can get initialized on the main thread
-            Log.Information("(1/3) Loading grasshopper");
-            var pluginObject = Rhino.RhinoApp.GetPlugInObject("Grasshopper");
-            var runheadless = pluginObject?.GetType().GetMethod("RunHeadless");
-            if (runheadless != null)
-                runheadless.Invoke(pluginObject, null);
-
-            Rhino.RhinoApp.SendWriteToConsole = false;
-
-            Log.Information("(2/3) Loading compute plug-ins");
-            var loadComputePlugins = typeof(Rhino.PlugIns.PlugIn).GetMethod("LoadComputeExtensionPlugins");
-            if (loadComputePlugins != null)
-                loadComputePlugins.Invoke(null, null);
-
             // NOTE:
+            // eirannejad 10/02/2024 (COMPUTE-268)
             // Ensure RhinoCode plugin (Rhino plugin) is loaded. This plugin registers scripting
             // languages and starts the scripting server that communicates with rhinocode CLI. It also makes
             // the ScriptEditor and RhinoCodeLogs commands available.
@@ -78,12 +65,42 @@ namespace compute.geometry
             // the script environments (especially python 3) will be initialized. This increases the execution
             // time on the first run on any script component. However after that the script components should run
             // normally. The scripting environment will only re-initialize when a new version of Rhino is installed.
-            Log.Information("(3/3) Loading rhino scripting plugin");
-            if (!Rhino.PlugIns.PlugIn.LoadPlugIn(s_rhinoCodePluginId))
+            // eirannejad 12/3/2024 (COMPUTE-268)
+            // This load is placed before Grasshopper in case GH needs to load any plugins published by the
+            // new scripting tools in Rhino >= 8
+            Log.Information("(1/3) Loading rhino scripting plugin");
+            if (Rhino.PlugIns.PlugIn.LoadPlugIn(s_rhinoCodePluginId))
             {
-                // If plugin load fails, let compute run, but log the error
+                Log.Information("Successfully loaded scripting plugin");
+
+                // eirannejad 12/3/2024 (COMPUTE-268)
+                // now configuring scripting env to avoid using rhino progressbar and
+                // dump init and package install messages to Rhino.RhinoApp.Write
+                if (Rhino.RhinoApp.GetPlugInObject(s_rhinoCodePluginId) is object rhinoCodeController)
+                {
+                    ((dynamic)rhinoCodeController).SendReportsToConsole = true;
+                    Log.Information("Configured scripting plugin for compute");
+                }
+            }
+            // If plugin load fails, let compute run, but log the error
+            else
+            {
                 Log.Error("Error loading rhino scripting plugin. Grasshopper script components are going to fail");
             }
+
+            // Load GH at startup so it can get initialized on the main thread
+            Log.Information("(2/3) Loading grasshopper");
+            var pluginObject = Rhino.RhinoApp.GetPlugInObject("Grasshopper");
+            var runheadless = pluginObject?.GetType().GetMethod("RunHeadless");
+            if (runheadless != null)
+                runheadless.Invoke(pluginObject, null);
+
+            Rhino.RhinoApp.SendWriteToConsole = false;
+
+            Log.Information("(3/3) Loading compute plug-ins");
+            var loadComputePlugins = typeof(Rhino.PlugIns.PlugIn).GetMethod("LoadComputeExtensionPlugins");
+            if (loadComputePlugins != null)
+                loadComputePlugins.Invoke(null, null);
 
             //ApiKey.Initialize(pipelines);
             //Rhino.Runtime.HostUtils.RegisterComputeEndpoint("grasshopper", typeof(Endpoints.GrasshopperEndpoint));

--- a/src/compute.geometry/Startup.cs
+++ b/src/compute.geometry/Startup.cs
@@ -31,7 +31,7 @@ namespace compute.geometry
         public void Configure(IApplicationBuilder app)
         {
             RhinoCoreStartup();
-            
+
             app.UseRouting();
             app.UseCors();
             //if (!String.IsNullOrEmpty(Config.ApiKey))
@@ -47,7 +47,8 @@ namespace compute.geometry
         {
             Program.RhinoCore = new Rhino.Runtime.InProcess.RhinoCore(null, Rhino.Runtime.InProcess.WindowStyle.NoWindow);
             Environment.SetEnvironmentVariable("RHINO_TOKEN", null, EnvironmentVariableTarget.Process);
-            Rhino.Runtime.HostUtils.OnExceptionReport += (source, ex) => {
+            Rhino.Runtime.HostUtils.OnExceptionReport += (source, ex) =>
+            {
                 Log.Error(ex, "An exception occurred while processing request");
                 Logging.LogExceptionData(ex);
             };


### PR DESCRIPTION
This really works when this PR (https://github.com/mcneel/rhino/pull/69060) merges on rhino 8 source.

Compute still works with older Rhino versions but it is with this version and higher that it can report scripting initialization and package installs to the compute console.

The rhinocode plugin load step is now step (1/3) before other plugins. This is mainly so if Grasshopper is loading any plugins published by the scripting tools in Rhino 8, it can still load the languages.

![WindowsTerminal_3w3mrZ0YH4](https://github.com/mcneel/compute.rhino3d/assets/8197916/1d784a5f-f0e5-4836-b644-ee7f89436afd)

Example of reporting package installs to console:

![WindowsTerminal_rhoBBIWBxQ](https://github.com/mcneel/compute.rhino3d/assets/8197916/74ee5a6a-e9fd-4596-8de0-ba5a7aca65e8)


RE: https://discourse.mcneel.com/t/jswan-over-hops-datatree-structure-issue/177686/4?u=andypayne