### PR TITLE
Pin ubuntu to 22.04 for github actions build

### DIFF
--- a/.github/workflows/workflow_ci.yml
+++ b/.github/workflows/workflow_ci.yml
@@ -47,7 +47,7 @@ jobs:
 
   build_compute:
     name: build compute
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [check_workflow, check_src]
     if: ${{ needs.check_src.outputs.any_changed == 'true' || needs.check_workflow.outputs.any_changed == 'true' }}
     steps:


### PR DESCRIPTION
Something changed with the distribution of the Microsoft.NET.Sdk.WindowsDesktop SDK between 22.04 and 24.04.

See https://stackoverflow.com/a/78737980