### PR TITLE
An option to enable a headless ActiveDoc

### DIFF
--- a/src/compute.geometry/Config.cs
+++ b/src/compute.geometry/Config.cs
@@ -34,6 +34,11 @@ namespace compute.geometry
         /// </summary>
         public static int LogRetainDays { get; private set; }
 
+        /// <summary>
+        /// RHINO_COMPUTE_CREATE_HEADLESS_DOC: create a headless Rhino document for each request.
+        /// </summary>
+        public static bool CreateHeadlessDoc { get; private set; }
+
         public static string[] GetDeprecationWarnings() => _warnings.ToArray();
 
         /// <summary>
@@ -50,6 +55,7 @@ namespace compute.geometry
             ApiKey = GetEnvironmentVariable<string>(RHINO_COMPUTE_KEY, null);
             LogPath = GetEnvironmentVariable(RHINO_COMPUTE_LOG_PATH, Path.Combine(Path.GetTempPath(), "Compute", "Logs"), COMPUTE_LOG_PATH);
             LogRetainDays = GetEnvironmentVariable(RHINO_COMPUTE_LOG_RETAIN_DAYS, 10, COMPUTE_LOG_RETAIN_DAYS);
+            CreateHeadlessDoc = GetEnvironmentVariable<bool>(RHINO_COMPUTE_CREATE_HEADLESS_DOC, false);
 
 #if DEBUG
             Debug = true;
@@ -73,6 +79,7 @@ namespace compute.geometry
         const string RHINO_COMPUTE_LOG_PATH = "RHINO_COMPUTE_LOG_PATH";
         const string RHINO_COMPUTE_LOG_RETAIN_DAYS = "RHINO_COMPUTE_LOG_RETAIN_DAYS";
         const string RHINO_COMPUTE_DEBUG = "RHINO_COMPUTE_DEBUG";
+        const string RHINO_COMPUTE_CREATE_HEADLESS_DOC = "RHINO_COMPUTE_CREATE_HEADLESS_DOC";
 
         // deprecated
         const string COMPUTE_BIND_URLS = "COMPUTE_BIND_URLS";

--- a/src/compute.geometry/Program.cs
+++ b/src/compute.geometry/Program.cs
@@ -45,6 +45,10 @@ namespace compute.geometry
 
             RhinoInside.Resolver.LoadRhino();
             LogVersions();
+
+            if (Config.CreateHeadlessDoc)
+                Log.Information("Compute to use headless Rhino documents");
+
             var host = Host.CreateDefaultBuilder(args)
                 .ConfigureWebHostDefaults(webBuilder =>
                 {

--- a/src/compute.geometry/ResthopperEndpoints.cs
+++ b/src/compute.geometry/ResthopperEndpoints.cs
@@ -15,6 +15,7 @@ using Carter;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
 using Rhino.Geometry;
+using Rhino;
 
 namespace compute.geometry
 {
@@ -74,6 +75,19 @@ namespace compute.geometry
 
             SetDefaultTolerances(input.AbsoluteTolerance, input.AngleTolerance);
             SetDefaultUnits(input.ModelUnits);
+
+            // Instantiate headless doc
+            if (Config.CreateHeadlessDoc)
+            {
+                RhinoDoc.ActiveDoc = RhinoDoc.CreateHeadless(null);
+                RhinoDoc.ActiveDoc.ModelAbsoluteTolerance = input.AbsoluteTolerance;
+                RhinoDoc.ActiveDoc.ModelAngleToleranceDegrees = input.AngleTolerance;
+
+                if (Enum.TryParse(input.ModelUnits, out UnitSystem units))
+                {
+                    RhinoDoc.ActiveDoc.ModelUnitSystem = units;
+                }
+            }
 
             int recursionLevel = input.RecursionLevel + 1;
             definition.Definition.DefineConstant("ComputeRecursionLevel", new Grasshopper.Kernel.Expressions.GH_Variant(recursionLevel));

--- a/src/compute.geometry/ResthopperEndpoints.cs
+++ b/src/compute.geometry/ResthopperEndpoints.cs
@@ -112,6 +112,11 @@ namespace compute.geometry
                     DataCache.SetCachedSolveResults(body, returnJson, definition);
                 }
             }
+
+            // Dispose headless doc
+            if (RhinoDoc.ActiveDoc is object)
+                RhinoDoc.ActiveDoc.Dispose();
+
             return returnJson;
         }
 


### PR DESCRIPTION
## Context
Many Grasshopper plugins rely on `RhinoDoc.ActiveDoc` for things like tolerances and units. By default, a Compute instance does not instantiate an `ActiveDoc`, which results in a `NullReferenceException` when plugins attempt to access its properties. There are workarounds that rely on the `Grasshopper.Utility` class, but those have to be implemented by the plugin's developer, which means that a number of third-party plugins cannot run on Compute.

## Purpose
The purpose of this pull request is to give users the option to create a headless `RhinoDoc.ActiveDoc` when they launch an instance of Compute. This will allow Grasshopper plugins to access `RhinoDoc.ActiveDoc` properties without throwing an exception.

## Description
The users will now be able to set a local environment variable called `RHINO_COMPUTE_CREATE_HEADLESS_DOC`. The value of this variable can be set to either `true` or `false` with `false` being the default. This variable is checked by the `Load()` method of the `compute.geometry.Config` static class and its value is assigned to the `CreateHeadlessDoc` property. 

Each time the `GrasshopperSolveHelper` method of the `ResthopperEndpointsModule` is invoked, it checks whether `Config.CreateHeadlessDoc` is set to `true`. If it is, a brand new headless document is instantiated with tolerances and units determined by the `input` object. To clarify, a brand new `ActiveDoc` is created at a worker level for each Compute request.

## Testing
This branch has been tested with both Hops and direct REST API calls from Python. The target Grasshopper script contained a C# component with calls to the `ActiveDoc` properties. Testing from Python was designed to flood several Compute workers with concurrent requests, each containing a unique combination of tolerances and units. Consistency between input ActiveDoc settings and the settings reported by the Grasshopper script was checked for each invocation to rule out possible conflicts between parallel `ActiveDoc` instances. No discrepancies or inconsistencies have been identified while testing under significant load.

![image](https://github.com/user-attachments/assets/f6bcf933-6d52-406d-9902-5a4ee6ec90d3)
