### PR TITLE
Add min max to Hops input description

### DIFF
--- a/src/hops/HopsComponent.cs
+++ b/src/hops/HopsComponent.cs
@@ -1140,12 +1140,12 @@ for value in values:
 
                         if (input.Minimum != null)
                         {
-                            inputDescription += $"\n Minimum: {input.Minimum}";
+                            inputDescription += $"\nMinimum: {input.Minimum}";
                         }
 
                         if (input.Maximum != null)
                         {
-                            inputDescription += $"\n Maximum: {input.Maximum}";
+                            inputDescription += $"\nMaximum: {input.Maximum}";
                         }
 
                         string nickname = name;

--- a/src/hops/HopsComponent.cs
+++ b/src/hops/HopsComponent.cs
@@ -1137,6 +1137,17 @@ for value in values:
                         string inputDescription = name;
                         if (!string.IsNullOrWhiteSpace(input.Description))
                             inputDescription = input.Description;
+
+                        if (input.Minimum != null)
+                        {
+                            inputDescription += $"\n Minimum: {input.Minimum}";
+                        }
+
+                        if (input.Maximum != null)
+                        {
+                            inputDescription += $"\n Maximum: {input.Maximum}";
+                        }
+
                         string nickname = name;
                         if (!string.IsNullOrWhiteSpace(input.Nickname))
                             nickname = input.Nickname;

--- a/src/hops/RemoteDefinition.cs
+++ b/src/hops/RemoteDefinition.cs
@@ -980,15 +980,17 @@ namespace Hops
             {
                 try
                 {
-                    if (Convert.ToDouble(item) < Convert.ToDouble(schema.Minimum))
+                    double schemaMinimum = Convert.ToDouble(schema.Minimum);
+                    if (Convert.ToDouble(item) < schemaMinimum)
                     {
-                        errors.Add(String.Format("{0} value must be greater than the specified minimum value of the parameter", name));
+                        errors.Add($"{name} value must be greater than the specified minimum value ({schemaMinimum}) of the parameter");
                         return false;
                     }
                 }
-                catch (Exception ex) { 
-                    errors.Add(ex.ToString()); 
-                    return false; 
+                catch (Exception ex)
+                {
+                    errors.Add(ex.ToString());
+                    return false;
                 }
 
             }
@@ -996,15 +998,17 @@ namespace Hops
             {
                 try
                 {
-                    if (Convert.ToDouble(item) > Convert.ToDouble(schema.Maximum))
+                    double schemaMaximum = Convert.ToDouble(schema.Maximum);
+                    if (Convert.ToDouble(item) > schemaMaximum)
                     {
-                        errors.Add(String.Format("{0} value must be smaller than the specified maximum value of the parameter", name));
+                        errors.Add($"{name} value must be smaller than the specified maximum value ({schemaMaximum}) of the parameter");
                         return false;
                     }
                 }
-                catch (Exception ex) { 
-                    errors.Add(ex.ToString()); 
-                    return false; 
+                catch (Exception ex)
+                {
+                    errors.Add(ex.ToString());
+                    return false;
                 }
             }
             return true;


### PR DESCRIPTION
### Context
I've noticed recently that Hops inputs will inherit `Minimum` and `Maximum` from sliders. When running script in Hops, the error pops up that the value is outside of min..max range but there is no way of knowing what the range is. 


![image](https://github.com/user-attachments/assets/a02378a8-64e4-4ac4-8c9b-9109ffc3a658)

### Solution
If input has any Minimum and Maximum, it gets added to input description (is there any better place for that?) and/or when user is outside of the range, the warning mentions what is the minimum/maximum value. 

It seems like a tree access property already follows similar logic and informs user expected number of items (as a warning).

![image](https://github.com/user-attachments/assets/1d856600-f48b-432f-95f7-6eb48b7ebcae)

Let me know if any of those would be possible to add, it would be helpful from user perspective to have some guidance on the accepted values range. 


### Comments
If the slider min..max inheritance is correct behavior, there is I think a bug - after unplugging the slider, Min Max is retained. 