### PR TITLE
Fix duplicate menu entries in Available Functions for URI-based sources

### DIFF
--- a/src/hops/HopsFunctionMgr.cs
+++ b/src/hops/HopsFunctionMgr.cs
@@ -43,9 +43,18 @@ namespace Hops
                 if (endpoints[1].Contains("/"))
                 {
                     var subendpoints = endpoints[1].Split(new[] { '/' }, 2);
-                    UriFunctionPathInfo functionPath = new UriFunctionPathInfo("/" + subendpoints[0], true);
-                    functionPath.RootURL = row.SourcePath;
-                    path.Paths.Add(functionPath);
+                    string endpointKey = "/" + subendpoints[0];
+
+                    // Check if this endpoint already exists to avoid duplicate menu entries
+                    UriFunctionPathInfo functionPath = path.Paths.Find(p => p.EndPoint == endpointKey);
+                    if (functionPath == null)
+                    {
+                        // Create new path only if it doesn't exist
+                        functionPath = new UriFunctionPathInfo(endpointKey, true);
+                        functionPath.RootURL = row.SourcePath;
+                        path.Paths.Add(functionPath);
+                    }
+
                     SeekFunctionMenuDirs(functionPath, "/" + subendpoints[1], fullpath, row);
                 }
                 else


### PR DESCRIPTION
When multiple components share a common URI path prefix (e.g., /prefix/component_1, /prefix/component_2, /prefix/component_3), each component would create a separate parent menu entry instead of grouping them under a single parent.

This fix checks if a parent path already exists in the Paths collection before creating a new one, ensuring components with shared prefixes are properly grouped under a single submenu.

Fixes #363

Related discussion: https://discourse.mcneel.com/t/grouping-hops-components-in-available-functions/195331