### PR TITLE
Add multipart/form-data support to reverse proxy for binary Grasshopper files

### DIFF
--- a/src/.idea/.idea.compute/.idea/indexLayout.xml
+++ b/src/.idea/.idea.compute/.idea/indexLayout.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="UserContentModel">
-    <attachedFolders />
-    <explicitIncludes />
-    <explicitExcludes />
-  </component>
-</project>

--- a/src/.idea/.idea.compute/.idea/indexLayout.xml
+++ b/src/.idea/.idea.compute/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/src/rhino.compute/ReverseProxy.cs
+++ b/src/rhino.compute/ReverseProxy.cs
@@ -102,7 +102,7 @@ namespace rhino.compute
             int parentProcessId = System.Convert.ToInt32(request.Query["parent"]);
             if (Program.IsParentRhinoProcess(parentProcessId))
             {
-                for (int i=0; i<children; i++)
+                for (int i = 0; i < children; i++)
                 {
                     ComputeChildren.LaunchCompute(false);
                 }
@@ -151,7 +151,7 @@ namespace rhino.compute
                     using (var sw = new System.IO.StreamReader(initialRequest.BodyReader.AsStream()))
                     {
                         string body = sw.ReadToEnd();
-                        using (var stringContent = new StringContent(body, System.Text.Encoding.UTF8, "applicaton/json"))
+                        using (var stringContent = new StringContent(body, System.Text.Encoding.UTF8, "application/json"))
                         {
                             req.Content = stringContent;
                             return await _client.SendAsync(req);

--- a/src/rhino.compute/ReverseProxy.cs
+++ b/src/rhino.compute/ReverseProxy.cs
@@ -133,7 +133,7 @@ namespace rhino.compute
                 using var req = new HttpRequestMessage(HttpMethod.Post, proxyUrl);
                 if (initialRequest.Headers.TryGetValue(_apiKeyHeader, out var keyHeader))
                     req.Headers.Add(_apiKeyHeader, keyHeader.ToString());
-
+                
                 var contentType = initialRequest.ContentType ?? string.Empty;
                 if (contentType.StartsWith("multipart/form-data", StringComparison.OrdinalIgnoreCase))
                 {

--- a/src/rhino.compute/ReverseProxy.cs
+++ b/src/rhino.compute/ReverseProxy.cs
@@ -130,10 +130,10 @@ namespace rhino.compute
             if (method == HttpMethod.Post)
             {
                 // include RhinoComputeKey header in request to compute child process
-                using var req = new HttpRequestMessage(HttpMethod.Post, proxyUrl);
+                var req = new HttpRequestMessage(HttpMethod.Post, proxyUrl);
                 if (initialRequest.Headers.TryGetValue(_apiKeyHeader, out var keyHeader))
                     req.Headers.Add(_apiKeyHeader, keyHeader.ToString());
-                
+
                 var contentType = initialRequest.ContentType ?? string.Empty;
                 if (contentType.StartsWith("multipart/form-data", StringComparison.OrdinalIgnoreCase))
                 {
@@ -146,13 +146,18 @@ namespace rhino.compute
                     return await _client.SendAsync(req);
                 }
 
-                using (var sw = new System.IO.StreamReader(initialRequest.BodyReader.AsStream()))
+                using (var stream = initialRequest.BodyReader.AsStream(false))
                 {
-                    string body = await sw.ReadToEndAsync();
-                    req.Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json");
+                    using (var sw = new System.IO.StreamReader(initialRequest.BodyReader.AsStream()))
+                    {
+                        string body = sw.ReadToEnd();
+                        using (var stringContent = new StringContent(body, System.Text.Encoding.UTF8, "applicaton/json"))
+                        {
+                            req.Content = stringContent;
+                            return await _client.SendAsync(req);
+                        }
+                    }
                 }
-
-                return await _client.SendAsync(req);
             }
 
             if (method == HttpMethod.Get)

--- a/src/rhino.compute/ReverseProxy.cs
+++ b/src/rhino.compute/ReverseProxy.cs
@@ -130,22 +130,29 @@ namespace rhino.compute
             if (method == HttpMethod.Post)
             {
                 // include RhinoComputeKey header in request to compute child process
-                var req = new HttpRequestMessage(HttpMethod.Post, proxyUrl);
+                using var req = new HttpRequestMessage(HttpMethod.Post, proxyUrl);
                 if (initialRequest.Headers.TryGetValue(_apiKeyHeader, out var keyHeader))
                     req.Headers.Add(_apiKeyHeader, keyHeader.ToString());
 
-                using (var stream = initialRequest.BodyReader.AsStream(false))
+                var contentType = initialRequest.ContentType ?? string.Empty;
+                if (contentType.StartsWith("multipart/form-data", StringComparison.OrdinalIgnoreCase))
                 {
-                    using (var sw = new System.IO.StreamReader(initialRequest.BodyReader.AsStream()))
-                    {
-                        string body = sw.ReadToEnd();
-                        using (var stringContent = new StringContent(body, System.Text.Encoding.UTF8, "applicaton/json"))
-                        {
-                            req.Content = stringContent;
-                            return await _client.SendAsync(req);
-                        }
-                    }
+                    var streamContent = new StreamContent(initialRequest.Body);
+                    streamContent.Headers.ContentType =
+                        System.Net.Http.Headers.MediaTypeHeaderValue.Parse(contentType);
+                    if (initialRequest.ContentLength.HasValue)
+                        streamContent.Headers.ContentLength = initialRequest.ContentLength.Value;
+                    req.Content = streamContent;
+                    return await _client.SendAsync(req);
                 }
+
+                using (var sw = new System.IO.StreamReader(initialRequest.BodyReader.AsStream()))
+                {
+                    string body = await sw.ReadToEndAsync();
+                    req.Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json");
+                }
+
+                return await _client.SendAsync(req);
             }
 
             if (method == HttpMethod.Get)


### PR DESCRIPTION
## Summary
- Add support for `multipart/form-data` POST requests in the reverse proxy, 
  enabling binary Grasshopper (.gh) files to be sent to rhino.compute for analysis
- Fix typo in content type (`"applicaton/json"` → `"application/json"`)

## Motivation
The reverse proxy previously only handled JSON POST bodies by reading them as 
strings over IIS. When sending binary Grasshopper files via `multipart/form-data`, the 
content was corrupted because it was forced through string encoding. 

The proxy now detects multipart requests and streams the body directly to the 
compute child process, preserving binary content integrity.

## Test
- [x] Verify sending a binary `.gh` file as `multipart/form-data` is forwarded correctly