### PR TITLE
Preserve URL scheme when building Hops solve endpoint

### DIFF
--- a/CHANGELOG.HOPS.md
+++ b/CHANGELOG.HOPS.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.16.29] - 2026-05-13
+## [0.16.29] - 2026-05-14
 
 ### Added
 
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - GET requests proxied through rhino.compute always returned HTTP 200, even when the upstream compute.geometry response was an error. The correct status code is now forwarded.
+- Fixed a security issue in the Hops client where solve requests sent to a remote server URL would silently downgrade HTTPS connections to HTTP. The original URL scheme is now preserved when constructing the solve endpoint, ensuring that API keys and definition payloads remain encrypted in transit when targeting an HTTPS server.
 
 ## [0.16.28] - 2025-11-05
 

--- a/src/hops/RemoteDefinition.cs
+++ b/src/hops/RemoteDefinition.cs
@@ -497,9 +497,8 @@ namespace Hops
             }
             else
             {
-                int index = Path.LastIndexOf('/');
-                var authority = new Uri(Path).Authority;
-                solveUrl = "http://" + authority + "/solve";
+                var uri = new Uri(Path);
+                solveUrl = $"{uri.Scheme}://{uri.Authority}/solve";
             }
 
             if (!string.IsNullOrEmpty(_filename)) inputSchema.FileName = _filename;


### PR DESCRIPTION
When solving against a remote server URL, the Hops client was rebuilding the solve endpoint with a hardcoded http:// scheme, silently downgrading HTTPS connections and sending API keys and definition payloads in cleartext. This change preserves the original URL scheme via new Uri(Path).Scheme. An adjacent unused int index variable is also removed.

Test plan:
- Point Hops at an https:// rhino.compute server (the remote-URL code path) and confirm the request stays on HTTPS.
- Confirm http:// URLs still work unchanged.
- Confirm local .gh paths, component GUIDs, and internalized definitions still solve (those paths use Servers.GetSolveUrl() and aren't touched by this change).