### PR TITLE
Surface Hops auto-upload fallback to the user

### DIFF
--- a/CHANGELOG.HOPS.md
+++ b/CHANGELOG.HOPS.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - GET requests proxied through rhino.compute always returned HTTP 200, even when the upstream compute.geometry response was an error. The correct status code is now forwarded.
 - Fixed a security issue in the Hops client where solve requests sent to a remote server URL would silently downgrade HTTPS connections to HTTP. The original URL scheme is now preserved when constructing the solve endpoint, ensuring that API keys and definition payloads remain encrypted in transit when targeting an HTTPS server.
+- The Hops auto-upload fallback (where Hops uploads the local .gh file to the remote server when the server returns HTTP 500) is now visible to the user. Hops adds a warning runtime message to the component listing the file name and destination URL, so the user knows when their local definition is being sent to the server. Behavior of the fallback itself is unchanged.
 
 ## [0.16.28] - 2025-11-05
 

--- a/src/hops/RemoteDefinition.cs
+++ b/src/hops/RemoteDefinition.cs
@@ -540,6 +540,11 @@ namespace Hops
                     bool fileExists = File.Exists(Path);
                     if (fileExists && string.IsNullOrEmpty(inputSchema.Algo))
                     {
+                        // Surface this via schema.Warnings rather than AddRuntimeMessage directly.
+                        // SetComponentOutputs reads schema.Warnings on the UI thread during the
+                        // results-application solve cycle, so it survives the async-mode clear
+                        // that BeforeSolveInstance does at the start of that cycle.
+                        string autoUploadMessage = $"Server returned HTTP 500. Uploaded local file '{System.IO.Path.GetFileName(Path)}' to {solveUrl} as a fallback.";
                         var bytes = System.IO.File.ReadAllBytes(Path);
                         string base64 = Convert.ToBase64String(bytes);
                         inputSchema.Algo = base64;
@@ -574,9 +579,12 @@ namespace Hops
                             var errorMsg = "Unable to solve on compute";
                             HopsLog.Log.Error(errorMsg);
                             badSchema.Errors.Add(errorMsg);
+                            badSchema.Warnings.Add(autoUploadMessage);
                             _parentComponent.HTTPRecord.Schema = badSchema;
                             return badSchema;
                         }
+                        if (schema != null)
+                            schema.Warnings.Add(autoUploadMessage);
                     }
                     else
                     {


### PR DESCRIPTION
When the remote compute server returns HTTP 500 and Hops has a local .gh file path, the existing fallback Base64-encodes the entire file and retries the request — a legitimate feature, but previously invisible to the user.
This change adds a warning runtime message to the Hops component identifying the file name and destination URL whenever the fallback fires. The message is appended to schema.Warnings, which SetComponentOutputs surfaces during the results-application solve cycle — so it appears correctly in both synchronous and asynchronous solve modes. Behavior of the fallback itself is unchanged.

Test plan:
- Point Hops at a local .gh file, configure the rhino.compute server URL to a remote server that does not have the file, and solve.
- Expect: solve succeeds via the upload fallback; the Hops component shows a yellow warning balloon listing the file and URL.
- Verify in both sync and async mode (toggleable in Hops preferences).