### PR TITLE
Internal cleanup of CollectDataHelper* and fix Min/Max validation on …

### DIFF
--- a/CHANGELOG.HOPS.md
+++ b/CHANGELOG.HOPS.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.16.29] - 2026-05-14
+## [0.16.29] - 2026-05-18
 
 ### Added
 
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GET requests proxied through rhino.compute always returned HTTP 200, even when the upstream compute.geometry response was an error. The correct status code is now forwarded.
 - Fixed a security issue in the Hops client where solve requests sent to a remote server URL would silently downgrade HTTPS connections to HTTP. The original URL scheme is now preserved when constructing the solve endpoint, ensuring that API keys and definition payloads remain encrypted in transit when targeting an HTTPS server.
 - The Hops auto-upload fallback (where Hops uploads the local .gh file to the remote server when the server returns HTTP 500) is now visible to the user. Hops adds a warning runtime message to the component listing the file name and destination URL, so the user knows when their local definition is being sent to the server. Behavior of the fallback itself is unchanged.
+- Min/Max bounds on Context Get Number and Context Get Integer parameters are now enforced when the parameter is set to tree access. Previously the bounds check silently never ran on tree inputs because of a type comparison bug, so out-of-bounds values flowed through without error. Item and list access were unaffected and behave as before.
 
 ## [0.16.28] - 2025-11-05
 

--- a/src/hops/RemoteDefinition.cs
+++ b/src/hops/RemoteDefinition.cs
@@ -1044,9 +1044,7 @@ namespace Hops
             GH_ParamAccess access,
             ref int inputCount,
             DataTree<ResthopperObject> dataTree,
-            ref List<string> warnings,
-            ref List<string> errors,
-            bool convertToGeometryBase = false)
+            ref List<string> errors)
         {
             string path = "{0}";
             var paramIndex = component?.Params.IndexOfInputParam(inputName);
@@ -1059,21 +1057,13 @@ namespace Hops
                 if (DA.GetData(inputName, ref t))
                 {
                     inputCount = 1;
-                    if (convertToGeometryBase)
+                    if (t is double || t is int)
                     {
-                        var gb = Grasshopper.Kernel.GH_Convert.ToGeometryBase(t);
-                        dataTree.Append(new ResthopperObject(gb), path);
+                        var passed = CheckMinMax<T>(t, inputName, schema, ref errors);
+                        if (!passed)
+                            return;
                     }
-                    else
-                    {
-                        if (t is double || t is int)
-                        {
-                            var passed = CheckMinMax<T>(t, inputName, schema, ref errors);
-                            if (!passed)
-                                return;
-                        }
-                        dataTree.Append(new ResthopperObject(t), path);
-                    }
+                    dataTree.Append(new ResthopperObject(t), path);
                 }
             }
             else if (access == GH_ParamAccess.list)
@@ -1084,21 +1074,13 @@ namespace Hops
                     inputCount = list.Count;
                     foreach (var item in list)
                     {
-                        if (convertToGeometryBase)
+                        if (item is double || item is int)
                         {
-                            var gb = Grasshopper.Kernel.GH_Convert.ToGeometryBase(item);
-                            dataTree.Append(new ResthopperObject(gb), path);
+                            var passed = CheckMinMax<T>(item, inputName, schema, ref errors);
+                            if (!passed)
+                                return;
                         }
-                        else
-                        {
-                            if (item is double || item is int)
-                            {
-                                var passed = CheckMinMax<T>(item, inputName, schema, ref errors);
-                                if (!passed)
-                                    return;
-                            }
-                            dataTree.Append(new ResthopperObject(item), path);
-                        }
+                        dataTree.Append(new ResthopperObject(item), path);
                     }
                 }
             }
@@ -1109,14 +1091,13 @@ namespace Hops
             }
         }
 
-        static void CollectDataHelper2<T, GHT>(IGH_DataAccess DA,
+        static void CollectDataHelperWithTree<T, GHT>(IGH_DataAccess DA,
             HopsComponent component,
             string inputName,
             InputParamSchema schema,
             GH_ParamAccess access,
             ref int inputCount,
             DataTree<ResthopperObject> dataTree,
-            ref List<string> warnings,
             ref List<string> errors) where GHT : GH_Goo<T>
         {
             if (access == GH_ParamAccess.tree)
@@ -1131,7 +1112,7 @@ namespace Hops
                         var items = tree[treePath];
                         foreach (var item in items)
                         {
-                            if (item is double || item is int)
+                            if (item.Value is double || item.Value is int)
                             {
                                 var passed = CheckMinMax<T>(item.Value, inputName, schema, ref errors);
                                 if (!passed)
@@ -1144,7 +1125,7 @@ namespace Hops
             }
             else
             {
-                CollectDataHelper<T>(DA, component, inputName, schema, access, ref inputCount, dataTree, ref warnings, ref errors);
+                CollectDataHelper<T>(DA, component, inputName, schema, access, ref inputCount, dataTree, ref errors);
             }
         }
 
@@ -1155,7 +1136,6 @@ namespace Hops
             GH_ParamAccess access,
             ref int inputCount,
             DataTree<ResthopperObject> dataTree,
-            ref List<string> warnings,
             ref List<string> errors)
         {
             string path = "{0}";
@@ -1208,7 +1188,6 @@ namespace Hops
             GH_ParamAccess access,
             ref int inputCount,
             DataTree<ResthopperObject> dataTree,
-            ref List<string> warnings,
             ref List<string> errors)
         {
             string path = "{0}";
@@ -1304,111 +1283,111 @@ namespace Hops
                     switch (param)
                     {
                         case Grasshopper.Kernel.Parameters.Param_Arc _:
-                            CollectDataHelper2<Arc, GH_Arc>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref warnings, ref errors);
+                            CollectDataHelperWithTree<Arc, GH_Arc>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Boolean _:
-                            CollectDataHelper2<bool, GH_Boolean>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref warnings, ref errors);
+                            CollectDataHelperWithTree<bool, GH_Boolean>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Box _:
-                            CollectDataHelper2<Box, GH_Box>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref warnings, ref errors);
+                            CollectDataHelperWithTree<Box, GH_Box>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Brep _:
-                            CollectDataHelper2<Brep, GH_Brep>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref warnings, ref errors);
+                            CollectDataHelperWithTree<Brep, GH_Brep>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Circle _:
-                            CollectDataHelper2<Circle, GH_Circle>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref warnings, ref errors);
+                            CollectDataHelperWithTree<Circle, GH_Circle>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Colour _:
-                            CollectDataHelper2<System.Drawing.Color, GH_Colour>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref warnings, ref errors);
+                            CollectDataHelperWithTree<System.Drawing.Color, GH_Colour>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Complex _:
-                            CollectDataHelper2<Complex, GH_ComplexNumber>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref warnings, ref errors);
+                            CollectDataHelperWithTree<Complex, GH_ComplexNumber>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Culture _:
-                            CollectDataHelper2<System.Globalization.CultureInfo, GH_Culture>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref warnings, ref errors);
+                            CollectDataHelperWithTree<System.Globalization.CultureInfo, GH_Culture>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Curve _:
-                            CollectDataHelper2<Curve, GH_Curve>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref warnings, ref errors);
+                            CollectDataHelperWithTree<Curve, GH_Curve>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Field _:
-                            CollectDataHelper<Grasshopper.Kernel.Types.GH_Field>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref warnings, ref errors);
+                            CollectDataHelper<Grasshopper.Kernel.Types.GH_Field>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_FilePath _:
-                            CollectDataHelper2<string, GH_String>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref warnings, ref errors);
+                            CollectDataHelperWithTree<string, GH_String>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_GenericObject _:
                             throw new Exception("generic param not supported");
                         case Grasshopper.Kernel.Parameters.Param_Geometry _:
-                            CollectDataHelperGeometryBase<IGH_GeometricGoo>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref warnings, ref errors);
+                            CollectDataHelperGeometryBase<IGH_GeometricGoo>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Group _:
                             throw new Exception("group param not supported");
                         case Grasshopper.Kernel.Parameters.Param_Guid _:
-                            CollectDataHelper2<Guid, GH_Guid>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref warnings, ref errors);
+                            CollectDataHelperWithTree<Guid, GH_Guid>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Integer _:
-                            CollectDataHelper2<int, GH_Integer>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref warnings, ref errors);
+                            CollectDataHelperWithTree<int, GH_Integer>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Interval _:
-                            CollectDataHelper2<Interval, GH_Interval>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref warnings, ref errors);
+                            CollectDataHelperWithTree<Interval, GH_Interval>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Interval2D _:
-                            CollectDataHelper2<UVInterval, GH_Interval2D>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref warnings, ref errors);
+                            CollectDataHelperWithTree<UVInterval, GH_Interval2D>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_LatLonLocation _:
                             throw new Exception("latlonlocation param not supported");
                         case Grasshopper.Kernel.Parameters.Param_Line _:
-                            CollectDataHelper2<Line, GH_Line>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref warnings, ref errors);
+                            CollectDataHelperWithTree<Line, GH_Line>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Matrix _:
-                            CollectDataHelper2<Matrix, GH_Matrix>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref warnings, ref errors);
+                            CollectDataHelperWithTree<Matrix, GH_Matrix>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Mesh _:
-                            CollectDataHelper2<Mesh, GH_Mesh>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref warnings, ref errors);
+                            CollectDataHelperWithTree<Mesh, GH_Mesh>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_MeshFace _:
-                            CollectDataHelper2<MeshFace, GH_MeshFace>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref warnings, ref errors);
+                            CollectDataHelperWithTree<MeshFace, GH_MeshFace>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_MeshParameters _:
-                            CollectDataHelper2<MeshingParameters, GH_MeshingParameters>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref warnings, ref errors);
+                            CollectDataHelperWithTree<MeshingParameters, GH_MeshingParameters>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Number _:
-                            CollectDataHelper2<double, GH_Number>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref warnings, ref errors);
+                            CollectDataHelperWithTree<double, GH_Number>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         //case Grasshopper.Kernel.Parameters.Param_OGLShader:
                         case Grasshopper.Kernel.Parameters.Param_Plane _:
-                            CollectDataHelper2<Plane, GH_Plane>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref warnings, ref errors);
+                            CollectDataHelperWithTree<Plane, GH_Plane>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Point _:
-                            CollectDataHelperPoints<Point3d>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref warnings, ref errors);
+                            CollectDataHelperPoints<Point3d>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Rectangle _:
-                            CollectDataHelper2<Rectangle3d, GH_Rectangle>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref warnings, ref errors);
+                            CollectDataHelperWithTree<Rectangle3d, GH_Rectangle>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         //case Grasshopper.Kernel.Parameters.Param_ScriptVariable _:
                         case Grasshopper.Kernel.Parameters.Param_String _:
-                            CollectDataHelper2<string, GH_String>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref warnings, ref errors);
+                            CollectDataHelperWithTree<string, GH_String>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_StructurePath _:
-                            CollectDataHelper2<Grasshopper.Kernel.Data.GH_Path, GH_StructurePath>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref warnings, ref errors);
+                            CollectDataHelperWithTree<Grasshopper.Kernel.Data.GH_Path, GH_StructurePath>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_SubD _:
-                            CollectDataHelper2<SubD, GH_SubD>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref warnings, ref errors);
+                            CollectDataHelperWithTree<SubD, GH_SubD>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Surface _:
-                            CollectDataHelper<Surface>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref warnings, ref errors);
+                            CollectDataHelper<Surface>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Time _:
-                            CollectDataHelper2<DateTime, GH_Time>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref warnings, ref errors);
+                            CollectDataHelperWithTree<DateTime, GH_Time>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Transform _:
-                            CollectDataHelper2<Transform, GH_Transform>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref warnings, ref errors);
+                            CollectDataHelperWithTree<Transform, GH_Transform>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Vector _:
-                            CollectDataHelper2<Vector3d, GH_Vector>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref warnings, ref errors);
+                            CollectDataHelperWithTree<Vector3d, GH_Vector>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Special.GH_NumberSlider _:
-                            CollectDataHelper2<double, GH_Number>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref warnings, ref errors);
+                            CollectDataHelperWithTree<double, GH_Number>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                     }
 


### PR DESCRIPTION
…tree inputs

Continuing the RemoteDefinition.cs cleanup track. This PR makes three internal changes plus one user-visible fix:

Cleanup (no behavior change):
- Removed the ref List<string> warnings parameter from all four CollectDataHelper* variants (and from the ~32 call sites in the dispatch switch). The parameter was never written to — only errors was. The surrounding AtLeast / AtMost warnings in CreateSolveInput are unaffected.
- Removed the unused bool convertToGeometryBase = false parameter from CollectDataHelper, plus the ~20 lines of dead if (convertToGeometryBase) {...} else {...} branches it gated. No caller ever passed true — that work happens in the dedicated
CollectDataHelperGeometryBase.

Fix (user-visible):
- In CollectDataHelper2's tree-access branch, item is double || item is int was always false because item is a GHT (a reference type), so Min/Max validation silently never ran on tree-access numerics. Now checks item.Value (typed as T), so Min/Max bounds on
Context Get Number and Context Get Integer parameters are properly enforced when set to tree access.
Test plan:
- Verified existing test .gh fixture (covering Param_X dispatches) still works.
- For the Min/Max fix specifically: set Min/Max on a Context Get Number with tree access; pass a value above Max via the data tree; confirm the bounds error fires (previously this would have flowed through silently).