### PR TITLE
Fix IndexOutOfRangeException in Hops when input branch counts differ

### DIFF
--- a/CHANGELOG.HOPS.md
+++ b/CHANGELOG.HOPS.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a security issue in the Hops client where solve requests sent to a remote server URL would silently downgrade HTTPS connections to HTTP. The original URL scheme is now preserved when constructing the solve endpoint, ensuring that API keys and definition payloads remain encrypted in transit when targeting an HTTPS server.
 - The Hops auto-upload fallback (where Hops uploads the local .gh file to the remote server when the server returns HTTP 500) is now visible to the user. Hops adds a warning runtime message to the component listing the file name and destination URL, so the user knows when their local definition is being sent to the server. Behavior of the fallback itself is unchanged.
 - Min/Max bounds on Context Get Number and Context Get Integer parameters are now enforced when the parameter is set to tree access. Previously the bounds check silently never ran on tree inputs because of a type comparison bug, so out-of-bounds values flowed through without error. Item and list access were unaffected and behave as before.
+- Fixed an IndexOutOfRangeException in the Hops client that occurred when two component inputs had different numbers of data-tree branches (for example a Series of 5 values and a Range of 10 values both grafted into the same component). Hops now clamps to the shorter input's last path index, matching Grasshopper's longest-list behavior for value access.
 
 ## [0.16.28] - 2025-11-05
 

--- a/src/hops/RemoteDefinition.cs
+++ b/src/hops/RemoteDefinition.cs
@@ -1029,12 +1029,20 @@ namespace Hops
         static string GetPathFromInputData(IGH_DataAccess DA, HopsComponent component, int paramIndex)
         {
             int pathIndex = 0;
-            if (component?.Params.Input[paramIndex].VolatileData?.PathCount > 1)
+            var volatileData = component?.Params.Input[paramIndex].VolatileData;
+            if (volatileData?.PathCount > 1)
                 pathIndex = DA.Iteration;
-            if (component?.Params.Input[paramIndex].VolatileData?.Paths.Count > 0)
-                return component?.Params.Input[paramIndex].VolatileData?.Paths?[pathIndex].ToString();
-            else
-                return null;
+            if (volatileData?.Paths.Count > 0)
+            {
+                // When two inputs have different path counts (e.g. Series of 5 vs Range of 10),
+                // DA.Iteration can exceed this input's path count once GH starts iterating the
+                // longer input. Clamp to the last valid index — matches Grasshopper's longest-list
+                // behavior, which DA.GetData already does for the value itself.
+                if (pathIndex >= volatileData.Paths.Count)
+                    pathIndex = volatileData.Paths.Count - 1;
+                return volatileData.Paths[pathIndex].ToString();
+            }
+            return null;
         }
 
         static void CollectDataHelper<T>(IGH_DataAccess DA,


### PR DESCRIPTION
When two inputs feeding a Hops component had different numbers of grafted data-tree branches (e.g. a Series of 5 values and a Range of 10 values both grafted), Hops crashed with IndexOutOfRangeException in GetPathFromInputData at RemoteDefinition.cs. Grasshopper drives iteration off the longest input, so DA.Iteration reaches the shorter input's Paths.Count and indexes past the end of its VolatileData.Paths collection.

The fix clamps pathIndex to the last valid index when DA.Iteration exceeds the input's path count. This matches Grasshopper's standard longest-list behavior — DA.GetData already returns the duplicated last value on those iterations, so clamping the path-string metadata just keeps it aligned with the value behavior.

No new helper or signature change — just a guarded index lookup and a local variable to deduplicate the component?.Params.Input[paramIndex].VolatileData chain.

Test plan:
- Send a Hops component a Series-of-5 and a Range-of-10, both grafted, on the same component. Pre-fix: crashes with IndexOutOfRangeException. Post-fix: completes; values from the shorter input are repeated against its last path.
- Equal-length case (Series-of-5 vs Range-of-5) still works unchanged.
- Existing test fixture from the recent RemoteDefinition.cs cleanup PRs still passes (no regression on item/list/tree access).