### PR TITLE
Consolidate output dispatches and modernize HttpClient usage in Hop

### DIFF
--- a/src/compute.geometry/GrasshopperDefinition.cs
+++ b/src/compute.geometry/GrasshopperDefinition.cs
@@ -521,183 +521,44 @@ namespace compute.geometry
                     if (goo == null)
                         continue;
 
-                    switch (goo)
+                    // GH_Surface unwraps to Brep (its .Value is a Brep), preserved from the original.
+                    // Unrecognized goo types are silently skipped, matching the original switch's
+                    // implicit fall-through to no-op.
+                    ResthopperObject resthopperObject = goo switch
                     {
-                        case GH_Boolean ghValue:
-                            {
-                                bool rhValue = ghValue.Value;
-                                resthopperObjectList.Add(GetResthopperObject<bool>(rhValue, rhinoVersion));
-                            }
-                            break;
-                        case GH_Point ghValue:
-                            {
-                                Point3d rhValue = ghValue.Value;
-                                resthopperObjectList.Add(GetResthopperObject<Point3d>(rhValue, rhinoVersion));
-                            }
-                            break;
-                        case GH_Vector ghValue:
-                            {
-                                Vector3d rhValue = ghValue.Value;
-                                resthopperObjectList.Add(GetResthopperObject<Vector3d>(rhValue, rhinoVersion));
-                            }
-                            break;
-                        case GH_Integer ghValue:
-                            {
-                                int rhValue = ghValue.Value;
-                                resthopperObjectList.Add(GetResthopperObject<int>(rhValue, rhinoVersion));
-                            }
-                            break;
-                        case GH_Number ghValue:
-                            {
-                                double rhValue = ghValue.Value;
-                                resthopperObjectList.Add(GetResthopperObject<double>(rhValue, rhinoVersion));
-                            }
-                            break;
-                        case GH_String ghValue:
-                            {
-                                string rhValue = ghValue.Value;
-                                resthopperObjectList.Add(GetResthopperObject<string>(rhValue, rhinoVersion));
-                            }
-                            break;
-                        case GH_SubD ghValue:
-                            {
-                                SubD rhValue = ghValue.Value;
-                                resthopperObjectList.Add(GetResthopperObject<SubD>(rhValue, rhinoVersion));
-                            }
-                            break;
-                        case GH_Line ghValue:
-                            {
-                                Line rhValue = ghValue.Value;
-                                resthopperObjectList.Add(GetResthopperObject<Line>(rhValue, rhinoVersion));
-                            }
-                            break;
-                        case GH_Curve ghValue:
-                            {
-                                Curve rhValue = ghValue.Value;
-                                resthopperObjectList.Add(GetResthopperObject<Curve>(rhValue, rhinoVersion));
-                            }
-                            break;
-                        case GH_Circle ghValue:
-                            {
-                                Circle rhValue = ghValue.Value;
-                                resthopperObjectList.Add(GetResthopperObject<Circle>(rhValue, rhinoVersion));
-                            }
-                            break;
-                        case GH_Arc ghValue:
-                            {
-                                Arc rhValue = ghValue.Value;
-                                resthopperObjectList.Add(GetResthopperObject<Arc>(rhValue, rhinoVersion));
-                            }
-                            break;
-                        case GH_Plane ghValue:
-                            {
-                                Plane rhValue = ghValue.Value;
-                                resthopperObjectList.Add(GetResthopperObject<Plane>(rhValue, rhinoVersion));
-                            }
-                            break;
-                        case GH_Rectangle ghValue:
-                            {
-                                Rectangle3d rhValue = ghValue.Value;
-                                resthopperObjectList.Add(GetResthopperObject<Rectangle3d>(rhValue, rhinoVersion));
-                            }
-                            break;
-                        case GH_Box ghValue:
-                            {
-                                Box rhValue = ghValue.Value;
-                                resthopperObjectList.Add(GetResthopperObject<Box>(rhValue, rhinoVersion));
-                            }
-                            break;
-                        case GH_Surface ghValue:
-                            {
-                                Brep rhValue = ghValue.Value;
-                                resthopperObjectList.Add(GetResthopperObject<Brep>(rhValue, rhinoVersion));
-                            }
-                            break;
-                        case GH_Brep ghValue:
-                            {
-                                Brep rhValue = ghValue.Value;
-                                resthopperObjectList.Add(GetResthopperObject<Brep>(rhValue, rhinoVersion));
-                            }
-                            break;
-                        case GH_Mesh ghValue:
-                            {
-                                Mesh rhValue = ghValue.Value;
-                                resthopperObjectList.Add(GetResthopperObject<Mesh>(rhValue, rhinoVersion));
-                            }
-                            break;
-                        case GH_Extrusion ghValue:
-                            {
-                                Extrusion rhValue = ghValue.Value;
-                                resthopperObjectList.Add(GetResthopperObject<Extrusion>(rhValue, rhinoVersion));
-                            }
-                            break;
-                        case GH_PointCloud ghValue:
-                            {
-                                PointCloud rhValue = ghValue.Value;
-                                resthopperObjectList.Add(GetResthopperObject<PointCloud>(rhValue, rhinoVersion));
-                            }
-                            break;
-                        case GH_InstanceReference ghValue:
-                            {
-                                InstanceReferenceGeometry rhValue = ghValue.Value;
-                                resthopperObjectList.Add(GetResthopperObject<InstanceReferenceGeometry>(rhValue, rhinoVersion));
-                            }
-                            break;
-                        case GH_Hatch ghValue:
-                            {
-                                Hatch rhValue = ghValue.Value;
-                                resthopperObjectList.Add(GetResthopperObject<Hatch>(rhValue, rhinoVersion));
-                            }
-                            break;
-                        case GH_LinearDimension ghValue:
-                            {
-                                LinearDimension rhValue = ghValue.Value;
-                                resthopperObjectList.Add(GetResthopperObject<LinearDimension>(rhValue, rhinoVersion));
-                            }
-                            break;
-                        case GH_RadialDimension ghValue:
-                            {
-                                RadialDimension rhValue = ghValue.Value;
-                                resthopperObjectList.Add(GetResthopperObject<RadialDimension>(rhValue, rhinoVersion));
-                            }
-                            break;
-                        case GH_AngularDimension ghValue:
-                            {
-                                AngularDimension rhValue = ghValue.Value;
-                                resthopperObjectList.Add(GetResthopperObject<AngularDimension>(rhValue, rhinoVersion));
-                            }
-                            break;
-                        case GH_OrdinateDimension ghValue:
-                            {
-                                OrdinateDimension rhValue = ghValue.Value;
-                                resthopperObjectList.Add(GetResthopperObject<OrdinateDimension>(rhValue, rhinoVersion));
-                            }
-                            break;
-                        case GH_Leader ghValue:
-                            {
-                                Leader rhValue = ghValue.Value;
-                                resthopperObjectList.Add(GetResthopperObject<Leader>(rhValue, rhinoVersion));
-                            }
-                            break;
-                        case GH_TextEntity ghValue:
-                            {
-                                TextEntity rhValue = ghValue.Value;
-                                resthopperObjectList.Add(GetResthopperObject<TextEntity>(rhValue, rhinoVersion));
-                            }
-                            break;
-                        case GH_TextDot ghValue:
-                            {
-                                TextDot rhValue = ghValue.Value;
-                                resthopperObjectList.Add(GetResthopperObject<TextDot>(rhValue, rhinoVersion));
-                            }
-                            break;
-                        case GH_Centermark ghValue:
-                            {
-                                Centermark rhValue = ghValue.Value;
-                                resthopperObjectList.Add(GetResthopperObject<Centermark>(rhValue, rhinoVersion));
-                            }
-                            break;
-                    }
+                        GH_Boolean g           => GetResthopperObject<bool>(g.Value, rhinoVersion),
+                        GH_Point g             => GetResthopperObject<Point3d>(g.Value, rhinoVersion),
+                        GH_Vector g            => GetResthopperObject<Vector3d>(g.Value, rhinoVersion),
+                        GH_Integer g           => GetResthopperObject<int>(g.Value, rhinoVersion),
+                        GH_Number g            => GetResthopperObject<double>(g.Value, rhinoVersion),
+                        GH_String g            => GetResthopperObject<string>(g.Value, rhinoVersion),
+                        GH_SubD g              => GetResthopperObject<SubD>(g.Value, rhinoVersion),
+                        GH_Line g              => GetResthopperObject<Line>(g.Value, rhinoVersion),
+                        GH_Curve g             => GetResthopperObject<Curve>(g.Value, rhinoVersion),
+                        GH_Circle g            => GetResthopperObject<Circle>(g.Value, rhinoVersion),
+                        GH_Arc g               => GetResthopperObject<Arc>(g.Value, rhinoVersion),
+                        GH_Plane g             => GetResthopperObject<Plane>(g.Value, rhinoVersion),
+                        GH_Rectangle g         => GetResthopperObject<Rectangle3d>(g.Value, rhinoVersion),
+                        GH_Box g               => GetResthopperObject<Box>(g.Value, rhinoVersion),
+                        GH_Surface g           => GetResthopperObject<Brep>(g.Value, rhinoVersion),
+                        GH_Brep g              => GetResthopperObject<Brep>(g.Value, rhinoVersion),
+                        GH_Mesh g              => GetResthopperObject<Mesh>(g.Value, rhinoVersion),
+                        GH_Extrusion g         => GetResthopperObject<Extrusion>(g.Value, rhinoVersion),
+                        GH_PointCloud g        => GetResthopperObject<PointCloud>(g.Value, rhinoVersion),
+                        GH_InstanceReference g => GetResthopperObject<InstanceReferenceGeometry>(g.Value, rhinoVersion),
+                        GH_Hatch g             => GetResthopperObject<Hatch>(g.Value, rhinoVersion),
+                        GH_LinearDimension g   => GetResthopperObject<LinearDimension>(g.Value, rhinoVersion),
+                        GH_RadialDimension g   => GetResthopperObject<RadialDimension>(g.Value, rhinoVersion),
+                        GH_AngularDimension g  => GetResthopperObject<AngularDimension>(g.Value, rhinoVersion),
+                        GH_OrdinateDimension g => GetResthopperObject<OrdinateDimension>(g.Value, rhinoVersion),
+                        GH_Leader g            => GetResthopperObject<Leader>(g.Value, rhinoVersion),
+                        GH_TextEntity g        => GetResthopperObject<TextEntity>(g.Value, rhinoVersion),
+                        GH_TextDot g           => GetResthopperObject<TextDot>(g.Value, rhinoVersion),
+                        GH_Centermark g        => GetResthopperObject<Centermark>(g.Value, rhinoVersion),
+                        _                      => null
+                    };
+                    if (resthopperObject != null)
+                        resthopperObjectList.Add(resthopperObject);
                 }
                 // preserve paths when returning data
                 outputTree.Add(path.ToString(), resthopperObjectList);

--- a/src/hops/Hops.csproj
+++ b/src/hops/Hops.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
+    <LangVersion>latest</LangVersion>
     <OutputType>Library</OutputType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/src/hops/RemoteDefinition.cs
+++ b/src/hops/RemoteDefinition.cs
@@ -144,11 +144,13 @@ namespace Hops
             {
                 try
                 {
-                    var getTask = HttpClient.GetAsync(path);
-                    var response = getTask.Result;
-                    string mediaType = response.Content.Headers.ContentType.MediaType.ToLowerInvariant();
-                    if (mediaType.Contains("json"))
-                        rc = PathType.Server;
+                    using (var cts = CreateTimeoutCts())
+                    {
+                        var response = HttpClient.GetAsync(path, cts.Token).Result;
+                        string mediaType = response.Content.Headers.ContentType.MediaType.ToLowerInvariant();
+                        if (mediaType.Contains("json"))
+                            rc = PathType.Server;
+                    }
                 }
                 catch (Exception)
                 {
@@ -232,7 +234,11 @@ namespace Hops
 
             IoResponseSchema responseSchema = null;
             System.Threading.Tasks.Task<System.Net.Http.HttpResponseMessage> responseTask;
-            IDisposable contentToDispose = null;
+            // Per-request disposables that need to outlive the if/else so the response can be
+            // awaited safely. Disposed in a single sweep at the end of the method.
+            System.Net.Http.StringContent contentToDispose = null;
+            System.Net.Http.HttpRequestMessage requestToDispose = null;
+            System.Threading.CancellationTokenSource ctsToDispose = null;
             if (performPost)
             {
                 string postUrl = Servers.GetDescriptionPostUrl();
@@ -254,7 +260,7 @@ namespace Hops
                         else
                         {
                             HopsLog.Log.Error($"File not found: {address}");
-                        }    
+                        }
                     }
                 }
                 else
@@ -274,18 +280,18 @@ namespace Hops
                 requestContent += "}";
                 _parentComponent.HTTPRecord.IORequest = requestContent;
                 var content = new System.Net.Http.StringContent(inputJson, Encoding.UTF8, "application/json");
-                HttpClient client = new HttpClient();
-                if(!String.IsNullOrEmpty(HopsAppSettings.APIKey))
-                    client.DefaultRequestHeaders.Add(_apiKeyName, HopsAppSettings.APIKey);
-                if(HopsAppSettings.HTTPTimeout > 0)
-                    client.Timeout = TimeSpan.FromSeconds(HopsAppSettings.HTTPTimeout);    
+                var request = new System.Net.Http.HttpRequestMessage(System.Net.Http.HttpMethod.Post, postUrl) { Content = content };
+                AddApiKeyHeader(request);
+                var cts = CreateTimeoutCts();
                 var fileNameMsg = String.Empty;
                 if (!String.IsNullOrEmpty(_filename))
-                    fileNameMsg = $" with {_filename}";            
+                    fileNameMsg = $" with {_filename}";
                 HopsLog.Log.Debug($"Sending POST request to {postUrl}{fileNameMsg}");
-                responseTask = client.PostAsync(postUrl, content);
+                responseTask = HttpClient.SendAsync(request, cts.Token);
                 _parentComponent.HTTPRecord.Schema = schema;
                 contentToDispose = content;
+                requestToDispose = request;
+                ctsToDispose = cts;
             }
             else
             {
@@ -294,7 +300,9 @@ namespace Hops
                 requestContent += "\"Method\": \"GET" + "\"" + Environment.NewLine;
                 requestContent += "}";
                 _parentComponent.HTTPRecord.IORequest = requestContent;
-                responseTask = HttpClient.GetAsync(address);
+                var cts = CreateTimeoutCts();
+                responseTask = HttpClient.GetAsync(address, cts.Token);
+                ctsToDispose = cts;
             }
             if (responseTask != null)
             {
@@ -318,8 +326,9 @@ namespace Hops
                 }
             }
 
-            if (contentToDispose != null)
-                contentToDispose.Dispose();
+            contentToDispose?.Dispose();
+            requestToDispose?.Dispose();
+            ctsToDispose?.Dispose();
 
             if (responseSchema != null)
             { 
@@ -464,12 +473,35 @@ namespace Hops
         {
             get
             {
-                if (_httpClient==null)
+                if (_httpClient == null)
                 {
-                    _httpClient = new System.Net.Http.HttpClient();
+                    // One shared HttpClient for all requests (avoids per-request socket allocation).
+                    // Timeout is intentionally infinite — per-request CancellationTokenSource
+                    // controls actual deadlines so HopsAppSettings.HTTPTimeout values larger than
+                    // 100s aren't capped by HttpClient's default.
+                    _httpClient = new System.Net.Http.HttpClient
+                    {
+                        Timeout = System.Threading.Timeout.InfiniteTimeSpan
+                    };
                 }
                 return _httpClient;
             }
+        }
+
+        // Per-request timeout via CancellationTokenSource. Uses HopsAppSettings.HTTPTimeout
+        // if configured, otherwise falls back to 100 seconds (HttpClient's historical default).
+        static System.Threading.CancellationTokenSource CreateTimeoutCts()
+        {
+            int seconds = HopsAppSettings.HTTPTimeout > 0 ? HopsAppSettings.HTTPTimeout : 100;
+            return new System.Threading.CancellationTokenSource(TimeSpan.FromSeconds(seconds));
+        }
+
+        // Adds the RhinoComputeKey header to the per-request HttpRequestMessage when an API
+        // key is configured. Headers must go on the request, not the shared HttpClient.
+        static void AddApiKeyHeader(System.Net.Http.HttpRequestMessage request)
+        {
+            if (!string.IsNullOrEmpty(HopsAppSettings.APIKey))
+                request.Headers.Add(_apiKeyName, HopsAppSettings.APIKey);
         }
         static Schema SafeSchemaDeserialize(string data)
         {
@@ -517,16 +549,14 @@ namespace Hops
             requestContent += "}";
             _parentComponent.HTTPRecord.SolveRequest = requestContent;
             using (var content = new System.Net.Http.StringContent(inputJson, Encoding.UTF8, "application/json"))
+            using (var request = new System.Net.Http.HttpRequestMessage(System.Net.Http.HttpMethod.Post, solveUrl) { Content = content })
+            using (var cts = CreateTimeoutCts())
             {
-                HttpClient client = new HttpClient();
-                if (!String.IsNullOrEmpty(HopsAppSettings.APIKey))
-                    client.DefaultRequestHeaders.Add(_apiKeyName, HopsAppSettings.APIKey);
-                if (HopsAppSettings.HTTPTimeout > 0)
-                    client.Timeout = TimeSpan.FromSeconds(HopsAppSettings.HTTPTimeout);
-                var postTask = client.PostAsync(solveUrl, content);
+                AddApiKeyHeader(request);
+                var postTask = HttpClient.SendAsync(request, cts.Token);
                 var fileNameMsg = String.Empty;
                 if (!String.IsNullOrEmpty(inputSchema.FileName))
-                    fileNameMsg = $" with {inputSchema.FileName} input values";                
+                    fileNameMsg = $" with {inputSchema.FileName} input values";
                 HopsLog.Log.Debug($"Sending POST request to {solveUrl}{fileNameMsg}");
                 var sw = Stopwatch.StartNew();
                 var responseMessage = postTask.Result;
@@ -540,10 +570,6 @@ namespace Hops
                     bool fileExists = File.Exists(Path);
                     if (fileExists && string.IsNullOrEmpty(inputSchema.Algo))
                     {
-                        // Surface this via schema.Warnings rather than AddRuntimeMessage directly.
-                        // SetComponentOutputs reads schema.Warnings on the UI thread during the
-                        // results-application solve cycle, so it survives the async-mode clear
-                        // that BeforeSolveInstance does at the start of that cycle.
                         string autoUploadMessage = $"Server returned HTTP 500. Uploaded local file '{System.IO.Path.GetFileName(Path)}' to {solveUrl} as a fallback.";
                         var bytes = System.IO.File.ReadAllBytes(Path);
                         string base64 = Convert.ToBase64String(bytes);
@@ -555,13 +581,11 @@ namespace Hops
                         requestContent += "\"content\":" + inputJson + Environment.NewLine;
                         requestContent += "}";
                         _parentComponent.HTTPRecord.SolveRequest = requestContent;
-                        var content2 = new System.Net.Http.StringContent(inputJson, Encoding.UTF8, "application/json");
-                        HttpClient client2 = new HttpClient();
-                        if (!String.IsNullOrEmpty(HopsAppSettings.APIKey))
-                            client2.DefaultRequestHeaders.Add(_apiKeyName, HopsAppSettings.APIKey);
-                        if (HopsAppSettings.HTTPTimeout > 0)
-                            client2.Timeout = TimeSpan.FromSeconds(HopsAppSettings.HTTPTimeout);
-                        postTask = client.PostAsync(solveUrl, content2);
+                        using var content2 = new System.Net.Http.StringContent(inputJson, Encoding.UTF8, "application/json");
+                        using var request2 = new System.Net.Http.HttpRequestMessage(System.Net.Http.HttpMethod.Post, solveUrl) { Content = content2 };
+                        using var cts2 = CreateTimeoutCts();
+                        AddApiKeyHeader(request2);
+                        postTask = HttpClient.SendAsync(request2, cts2.Token);
                         var fileNameMsg2 = String.Empty;
                         if (!String.IsNullOrEmpty(inputSchema.FileName))
                             fileNameMsg2 = $" with {inputSchema.FileName} input values";
@@ -730,90 +754,39 @@ namespace Hops
         static IGH_Goo GooFromResthopperObject(ResthopperObject obj)
         {
             if (obj.ResolvedData != null)
-                return obj.ResolvedData as Grasshopper.Kernel.Types.IGH_Goo;
-            
+                return obj.ResolvedData as IGH_Goo;
+
             string data = obj.Data.Trim('"');
+
+            // Simple types: parse or JSON-deserialize and wrap. Each entry is cached on
+            // obj.ResolvedData so subsequent calls skip the work.
+            IGH_Goo simpleResult = obj.Type switch
+            {
+                "System.Boolean"             => new GH_Boolean(bool.Parse(data)),
+                "System.Double"              => new GH_Number(double.Parse(data)),
+                "System.String"              => new GH_String(MaybeUnescapeJsonString(data)),
+                "System.Int32"               => new GH_Integer(int.Parse(data)),
+                "Rhino.Geometry.Circle"      => new GH_Circle(JsonConvert.DeserializeObject<Circle>(data)),
+                "Rhino.Geometry.Arc"         => new GH_Arc(JsonConvert.DeserializeObject<Arc>(data)),
+                "Rhino.Geometry.Line"        => new GH_Line(JsonConvert.DeserializeObject<Line>(data)),
+                "Rhino.Geometry.Rectangle3d" => new GH_Rectangle(JsonConvert.DeserializeObject<Rectangle3d>(data)),
+                "Rhino.Geometry.Plane"       => new GH_Plane(JsonConvert.DeserializeObject<Plane>(data)),
+                "Rhino.Geometry.Point3d"     => new GH_Point(JsonConvert.DeserializeObject<Point3d>(data)),
+                "Rhino.Geometry.Vector3d"    => new GH_Vector(JsonConvert.DeserializeObject<Vector3d>(data)),
+                "Rhino.Geometry.Box"         => new GH_Box(JsonConvert.DeserializeObject<Box>(data)),
+                _                            => null
+            };
+            if (simpleResult != null)
+            {
+                obj.ResolvedData = simpleResult;
+                return simpleResult;
+            }
+
+            // CommonObject geometry types: deserialize as dictionary, rehydrate via FromJSON,
+            // wrap based on runtime type. Original did not cache these on obj.ResolvedData
+            // (preserved).
             switch (obj.Type)
             {
-                case "System.Boolean":
-                    {
-                        var boolResult = new Grasshopper.Kernel.Types.GH_Boolean(bool.Parse(data));
-                        obj.ResolvedData = boolResult;
-                        return boolResult;
-                    }
-                case "System.Double":
-                    {
-                        var doubleResult = new Grasshopper.Kernel.Types.GH_Number(double.Parse(data));
-                        obj.ResolvedData = doubleResult;
-                        return doubleResult;
-                    }
-                case "System.String":
-                    {
-                        string unescaped = data;
-                        // TODO: This is a a hack. I understand that JSON needs to escape
-                        // embedded JSON, but I'm not particularly happy with the following code
-                        if (unescaped.Trim().StartsWith("{") && unescaped.Contains("\\"))
-                        {
-                            unescaped = System.Text.RegularExpressions.Regex.Unescape(data);
-                        }
-                        var stringResult = new Grasshopper.Kernel.Types.GH_String(unescaped);
-                        obj.ResolvedData = stringResult;
-                        return stringResult;
-                    }
-                case "System.Int32":
-                    {
-                        var intResult = new Grasshopper.Kernel.Types.GH_Integer(int.Parse(data));
-                        obj.ResolvedData = intResult;
-                        return intResult;
-                    }
-                case "Rhino.Geometry.Circle":
-                    {
-                        var circleResult = new Grasshopper.Kernel.Types.GH_Circle(JsonConvert.DeserializeObject<Circle>(data));
-                        obj.ResolvedData = circleResult;
-                        return circleResult;
-                    }
-                case "Rhino.Geometry.Arc":
-                    {
-                        var arcResult = new Grasshopper.Kernel.Types.GH_Arc(JsonConvert.DeserializeObject<Arc>(data));
-                        obj.ResolvedData = arcResult;
-                        return arcResult;
-                    }
-                case "Rhino.Geometry.Line":
-                    {
-                        var lineResult = new Grasshopper.Kernel.Types.GH_Line(JsonConvert.DeserializeObject<Line>(data));
-                        obj.ResolvedData = lineResult;
-                        return lineResult;
-                    }
-                case "Rhino.Geometry.Rectangle3d":
-                    {
-                        var rectangleResult = new Grasshopper.Kernel.Types.GH_Rectangle(JsonConvert.DeserializeObject<Rectangle3d>(data));
-                        obj.ResolvedData = rectangleResult;
-                        return rectangleResult;
-                    }
-                case "Rhino.Geometry.Plane":
-                    {
-                        var planeResult = new Grasshopper.Kernel.Types.GH_Plane(JsonConvert.DeserializeObject<Plane>(data));
-                        obj.ResolvedData = planeResult;
-                        return planeResult;
-                    }
-                case "Rhino.Geometry.Point3d":
-                    {
-                        var pointResult = new Grasshopper.Kernel.Types.GH_Point(JsonConvert.DeserializeObject<Point3d>(data));
-                        obj.ResolvedData = pointResult;
-                        return pointResult;
-                    }
-                case "Rhino.Geometry.Vector3d":
-                    {
-                        var vectorResult = new Grasshopper.Kernel.Types.GH_Vector(JsonConvert.DeserializeObject<Vector3d>(data));
-                        obj.ResolvedData = vectorResult;
-                        return vectorResult;
-                    }
-                case "Rhino.Geometry.Box":
-                    {
-                        var boxResult = new Grasshopper.Kernel.Types.GH_Box(JsonConvert.DeserializeObject<Box>(data));
-                        obj.ResolvedData = boxResult;
-                        return boxResult;
-                    }
                 case "Rhino.Geometry.Brep":
                 case "Rhino.Geometry.Curve":
                 case "Rhino.Geometry.Extrusion":
@@ -832,54 +805,15 @@ namespace Hops
                 case "Rhino.Geometry.TextEntity":
                 case "Rhino.Geometry.TextDot":
                 case "Rhino.Geometry.Leader":
-                    {
-                        Dictionary<string, string> dict = JsonConvert.DeserializeObject<Dictionary<string, string>>(data);
-                        var geometry = Rhino.Runtime.CommonObject.FromJSON(dict);
-                        if (geometry is Extrusion)
-                            return new Grasshopper.Kernel.Types.GH_Extrusion(geometry as Extrusion);
-                        if (geometry is Surface)
-                            return new Grasshopper.Kernel.Types.GH_Surface(geometry as Surface);
-                        if (geometry is Brep brep)
-                        {
-                           if(brep.Faces.Count > 1)
-                           {
-                                return new Grasshopper.Kernel.Types.GH_Brep(brep);
-                           }
-                           else
-                           {
-                                return new Grasshopper.Kernel.Types.GH_Surface(brep);
-                           }
-                        }   
-                        if (geometry is Curve)
-                            return new Grasshopper.Kernel.Types.GH_Curve(geometry as Curve);
-                        if (geometry is Mesh)
-                            return new Grasshopper.Kernel.Types.GH_Mesh(geometry as Mesh);
-                        if (geometry is SubD)
-                            return new Grasshopper.Kernel.Types.GH_SubD(geometry as SubD);
-                        if (geometry is PointCloud)
-                            return new Grasshopper.Kernel.Types.GH_PointCloud(geometry as PointCloud);
-                        if (geometry is InstanceReferenceGeometry)
-                            return new Grasshopper.Kernel.Types.GH_InstanceReference(geometry as InstanceReferenceGeometry);
-                        if (geometry is Hatch)
-                            return new Grasshopper.Kernel.Types.GH_Hatch(geometry as Hatch);
-                        if (geometry is LinearDimension)
-                            return new Grasshopper.Kernel.Types.GH_LinearDimension(geometry as LinearDimension);
-                        if (geometry is AngularDimension)
-                            return new Grasshopper.Kernel.Types.GH_AngularDimension(geometry as AngularDimension);
-                        if (geometry is RadialDimension)
-                            return new Grasshopper.Kernel.Types.GH_RadialDimension(geometry as RadialDimension);
-                        if (geometry is OrdinateDimension)
-                            return new Grasshopper.Kernel.Types.GH_OrdinateDimension(geometry as OrdinateDimension);
-                        if (geometry is TextEntity)
-                            return new Grasshopper.Kernel.Types.GH_TextEntity(geometry as TextEntity);
-                        if (geometry is TextDot)
-                            return new Grasshopper.Kernel.Types.GH_TextDot(geometry as TextDot);
-                        if (geometry is Leader)
-                            return new Grasshopper.Kernel.Types.GH_Leader(geometry as Leader);
-                    }
+                    var explicitResult = DeserializeExplicitGeometry(data);
+                    if (explicitResult != null)
+                        return explicitResult;
                     break;
             }
 
+            // Fallback for any Rhino.Geometry.* type not handled above: dynamic type resolution
+            // via the assembly that owns Point3d. Surface gets converted to Brep here (different
+            // from the explicit case above, which keeps it as GH_Surface) — preserved verbatim.
             if (obj.Type.StartsWith("Rhino.Geometry"))
             {
                 var pt = new Rhino.Geometry.Point3d();
@@ -890,23 +824,63 @@ namespace Hops
                 System.Type type = System.Type.GetType(sType);
                 if (type != null && typeof(GeometryBase).IsAssignableFrom(type))
                 {
-                    Dictionary<string, string> dict = JsonConvert.DeserializeObject<Dictionary<string, string>>(data);
+                    var dict = JsonConvert.DeserializeObject<Dictionary<string, string>>(data);
                     var geometry = Rhino.Runtime.CommonObject.FromJSON(dict);
-                    Surface surface = geometry as Surface;
-                    if (surface != null)
+                    if (geometry is Surface surface)
                         geometry = surface.ToBrep();
-                    if (geometry is Brep)
-                        return new Grasshopper.Kernel.Types.GH_Brep(geometry as Brep);
-                    if (geometry is Curve)
-                        return new Grasshopper.Kernel.Types.GH_Curve(geometry as Curve);
-                    if (geometry is Mesh)
-                        return new Grasshopper.Kernel.Types.GH_Mesh(geometry as Mesh);
-                    if (geometry is SubD)
-                        return new Grasshopper.Kernel.Types.GH_SubD(geometry as SubD);
+                    IGH_Goo fallbackResult = geometry switch
+                    {
+                        Brep brep   => new GH_Brep(brep),
+                        Curve curve => new GH_Curve(curve),
+                        Mesh mesh   => new GH_Mesh(mesh),
+                        SubD subD   => new GH_SubD(subD),
+                        _           => null
+                    };
+                    if (fallbackResult != null)
+                        return fallbackResult;
                 }
             }
 
             throw new Exception("Unable to convert resthopper data");
+        }
+
+        // System.String values may arrive as raw JSON-escaped content (e.g. an embedded JSON
+        // object); detect the escape pattern and unescape so GH_String holds the plain text.
+        static string MaybeUnescapeJsonString(string data)
+        {
+            if (data.Trim().StartsWith("{") && data.Contains("\\"))
+                return System.Text.RegularExpressions.Regex.Unescape(data);
+            return data;
+        }
+
+        // CommonObject geometry deserializer for the explicit-type cases in GooFromResthopperObject.
+        // Order matters: Extrusion : Surface, so Extrusion must come first. A multi-face Brep
+        // wraps as GH_Brep; a single-face Brep wraps as GH_Surface (preserved from original).
+        static IGH_Goo DeserializeExplicitGeometry(string data)
+        {
+            var dict = JsonConvert.DeserializeObject<Dictionary<string, string>>(data);
+            var geometry = Rhino.Runtime.CommonObject.FromJSON(dict);
+            return geometry switch
+            {
+                Extrusion ext                       => new GH_Extrusion(ext),
+                Surface surface                     => new GH_Surface(surface),
+                Brep brep when brep.Faces.Count > 1 => new GH_Brep(brep),
+                Brep brep                           => new GH_Surface(brep),
+                Curve curve                         => new GH_Curve(curve),
+                Mesh mesh                           => new GH_Mesh(mesh),
+                SubD subD                           => new GH_SubD(subD),
+                PointCloud pc                       => new GH_PointCloud(pc),
+                InstanceReferenceGeometry iref      => new GH_InstanceReference(iref),
+                Hatch hatch                         => new GH_Hatch(hatch),
+                LinearDimension lin                 => new GH_LinearDimension(lin),
+                AngularDimension ang                => new GH_AngularDimension(ang),
+                RadialDimension rad                 => new GH_RadialDimension(rad),
+                OrdinateDimension ord               => new GH_OrdinateDimension(ord),
+                TextEntity text                     => new GH_TextEntity(text),
+                TextDot textDot                     => new GH_TextDot(textDot),
+                Leader leader                       => new GH_Leader(leader),
+                _                                   => null
+            };
         }
 
         static List<IGH_Param> _params;


### PR DESCRIPTION
Continuation of the RemoteDefinition.cs / GrasshopperDefinition.cs cleanup track. This PR collapses two more type-dispatch hot spots and modernizes Hops' HTTP layer.

D1 — GrasshopperDefinition.SerializeDataTree (compute.geometry, output side) 29-case switch on GH goo types collapsed into a one-line-per-case switch expression. Mirrors the A1/A2 refactors. Unknown types still fall through to no-op.
D2 — RemoteDefinition.GooFromResthopperObject (Hops, input side) Two-stage dispatch: simple type cases (12) → switch expression with shared obj.ResolvedData caching; geometry mega-case (18 Rhino.Geometry.* types) → preserved case labels but body extracted to a DeserializeExplicitGeometry helper using pattern matching. Order-sensitive cases preserved (Extrusion before Surface, single-face Brep wraps as GH_Surface, multi-face as GH_Brep). Fallback path's Surface.ToBrep() conversion preserved with a comment flagging the asymmetry with the explicit case.
D3 — HttpClient modernization (Hops, all 5 HTTP call sites) The three POST sites previously created a fresh HttpClient per request and set DefaultRequestHeaders / Timeout on it — a known anti-pattern that risks socket exhaustion under load. All 5 sites now use the existing _httpClient singleton via SendAsync / GetAsync with:
- Per-request CancellationTokenSource for timeout (honors HopsAppSettings.HTTPTimeout, falls back to 100s — preserving today's behavior including timeouts > 100s).
- Per-request HttpRequestMessage headers for API key (avoids mutating shared client state).
- Singleton's Timeout set to Timeout.InfiniteTimeSpan so the CTS is authoritative.
- Latent typo fixed in the retry POST (client.PostAsync → meant client2.PostAsync; same config so behavior unchanged, but eliminated by switching to the singleton). Also added <LangVersion>latest</LangVersion> to Hops.csproj so the project (targeting net48) can use C# 8+ features (switch expressions, using var, pattern matching when). No runtime impact — the IL is back-compatible with .NET Framework 4.8.

Stats: 3 files changed, 186 insertions, 346 deletions (net −160).

Test plan:
- Existing .gh test fixture against all input types — covers D1/D2.
- Solve with no API key (default timeout) — sanity.
- Solve with API key configured in Hops preferences — verifies per-request header.
- Solve with HTTPTimeout = 300 — verifies long timeouts still work through the shared client.
- Trigger the auto-upload fallback (point Hops at a remote server that doesn't have the file) — exercises the retry POST.
- Multiple Hops components solving concurrently — sanity check that the shared client doesn't choke under load.

Followup PR will replace the deprecated WebClient / WebRequest.Create usage in compute.geometry (DataCache.cs, GrasshopperDefinition.cs, RhinoComputeAsync.cs) to clear the remaining SYSLIB0014 warnings.