### PR TITLE
Fix double-encoded string round-trip in Hops for paths and quoted text

### DIFF
--- a/CHANGELOG.HOPS.md
+++ b/CHANGELOG.HOPS.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.16.29] - 2026-05-18
+## [0.16.29] - 2026-05-19
 
 ### Added
 
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The Hops auto-upload fallback (where Hops uploads the local .gh file to the remote server when the server returns HTTP 500) is now visible to the user. Hops adds a warning runtime message to the component listing the file name and destination URL, so the user knows when their local definition is being sent to the server. Behavior of the fallback itself is unchanged.
 - Min/Max bounds on Context Get Number and Context Get Integer parameters are now enforced when the parameter is set to tree access. Previously the bounds check silently never ran on tree inputs because of a type comparison bug, so out-of-bounds values flowed through without error. Item and list access were unaffected and behave as before.
 - Fixed an IndexOutOfRangeException in the Hops client that occurred when two component inputs had different numbers of data-tree branches (for example a Series of 5 values and a Range of 10 values both grafted into the same component). Hops now clamps to the shorter input's last path index, matching Grasshopper's longest-list behavior for value access.
+- Fixed a pair of JSON-encoding bugs in the Hops client that caused string values to round-trip incorrectly. On the input side, default string values for Context Get String and Context Get File Path inputs arrived with literal JSON quote characters baked in, so a default value of `Andy` would end up producing `"Andy"` (with surrounding quotes) downstream. On the output side, string values coming back from compute kept JSON escape sequences intact (so a file path `C:\Users\file.txt` would come back as `C:\\Users\\file.txt`). Both paths now use a proper JSON-string decoder; backslashes and file paths round-trip correctly.
 
 ## [0.16.28] - 2025-11-05
 

--- a/src/hops/HopsComponent.cs
+++ b/src/hops/HopsComponent.cs
@@ -963,6 +963,18 @@ for value in values:
             }
         }
 
+        static string DecodeStringDefault(string data)
+        {
+            try
+            {
+                return JsonConvert.DeserializeObject<string>(data);
+            }
+            catch (Exception)
+            {
+                return System.Text.RegularExpressions.Regex.Unescape(data);
+            }
+        }
+
         public void HopsAddRuntimeMessage(GH_RuntimeMessageLevel level, string message)
         {
             if(HopsLog.Log is object)
@@ -1446,7 +1458,7 @@ for value in values:
                                                 List<ResthopperObject> items = branch.Value;
                                                 foreach (var item in items)
                                                 {
-                                                    (mgr[paramIndex] as Grasshopper.Kernel.Parameters.Param_String).PersistentData.Append(new GH_String(item.Data.ToString()), path);
+                                                    (mgr[paramIndex] as Grasshopper.Kernel.Parameters.Param_String).PersistentData.Append(new GH_String(DecodeStringDefault(item.Data.ToString())), path);
                                                 }
                                             }
                                         }
@@ -1454,7 +1466,7 @@ for value in values:
                                     else
                                     {
                                         (mgr[paramIndex] as Grasshopper.Kernel.Parameters.Param_String).PersistentData.Append(new GH_String(input.Default.ToString()));
-                                    }  
+                                    }
                                 }
                                 break;
                             case Grasshopper.Kernel.Parameters.Param_GenericObject _:
@@ -1873,7 +1885,7 @@ for value in values:
                                                 List<ResthopperObject> items = branch.Value;
                                                 foreach (var item in items)
                                                 {
-                                                    (mgr[paramIndex] as Grasshopper.Kernel.Parameters.Param_String).PersistentData.Append(new GH_String(item.Data.ToString()), path);
+                                                    (mgr[paramIndex] as Grasshopper.Kernel.Parameters.Param_String).PersistentData.Append(new GH_String(DecodeStringDefault(item.Data.ToString())), path);
                                                 }
                                             }
                                         }
@@ -1881,7 +1893,7 @@ for value in values:
                                     else
                                     {
                                         (mgr[paramIndex] as Grasshopper.Kernel.Parameters.Param_String).PersistentData.Append(new GH_String(input.Default.ToString()));
-                                    }     
+                                    }
                                 }
                                 break;
                             case Grasshopper.Kernel.Parameters.Param_StructurePath _:

--- a/src/hops/RemoteDefinition.cs
+++ b/src/hops/RemoteDefinition.cs
@@ -764,7 +764,7 @@ namespace Hops
             {
                 "System.Boolean"             => new GH_Boolean(bool.Parse(data)),
                 "System.Double"              => new GH_Number(double.Parse(data)),
-                "System.String"              => new GH_String(MaybeUnescapeJsonString(data)),
+                "System.String"              => new GH_String(DecodeJsonString(obj.Data)),
                 "System.Int32"               => new GH_Integer(int.Parse(data)),
                 "Rhino.Geometry.Circle"      => new GH_Circle(JsonConvert.DeserializeObject<Circle>(data)),
                 "Rhino.Geometry.Arc"         => new GH_Arc(JsonConvert.DeserializeObject<Arc>(data)),
@@ -844,8 +844,27 @@ namespace Hops
             throw new Exception("Unable to convert resthopper data");
         }
 
-        // System.String values may arrive as raw JSON-escaped content (e.g. an embedded JSON
-        // object); detect the escape pattern and unescape so GH_String holds the plain text.
+        // Decode a JSON-encoded string from the wire (the form produced by JsonConvert.SerializeObject
+        // for any non-geometry type — surrounded by quote chars with escape sequences for backslashes,
+        // embedded quotes, etc.). The primary path uses JsonConvert.DeserializeObject<string> which
+        // correctly reverses JSON escapes — so a file path like "C:\\Users\\file.txt" on the wire
+        // comes back as "C:\Users\file.txt". Falls back to the legacy embedded-JSON-object handling
+        // for malformed input that isn't a valid JSON string literal.
+        static string DecodeJsonString(string objData)
+        {
+            try
+            {
+                return JsonConvert.DeserializeObject<string>(objData);
+            }
+            catch (Exception)
+            {
+                return MaybeUnescapeJsonString(objData.Trim('"'));
+            }
+        }
+
+        // Legacy fallback for malformed wire payloads that contain an embedded JSON object
+        // as a string (e.g. "{\"key\":\"value\"}" with literal backslash-quote pairs that
+        // a strict JSON string decoder would reject). Preserves the prior heuristic exactly.
         static string MaybeUnescapeJsonString(string data)
         {
             if (data.Trim().StartsWith("{") && data.Contains("\\"))


### PR DESCRIPTION
Two related JSON-encoding bugs caused string values to round-trip incorrectly between Hops and compute. Both share the same root cause — code that hand-rolled JSON quote handling (Trim('"'), embedded-JSON-object heuristics) instead of using JsonConvert.DeserializeObject<string> to decode the wire format properly.

Input side (HopsComponent.cs) — When the Hops component pulls input defaults from compute's /io response, the Param_String and Param_FilePath cases applied the wire-format value to PersistentData directly, so a default of Andy ended up baked in as the 6-character string "Andy" (with literal quote chars). New helper DecodeStringDefault JSON-decodes the wire value before it's stuffed into GH_String, with a Regex.Unescape fallback for malformed input.

Output side (RemoteDefinition.GooFromResthopperObject) — Strings returned from compute kept their JSON escape sequences intact because the decoder only stripped outer quotes (obj.Data.Trim('"')) and never unescaped \\, \", etc. A file path C:\Users\file.txt came back as C:\\Users\\file.txt. New helper DecodeJsonString properly JSON-decodes, falling back to the legacy MaybeUnescapeJsonString heuristic for malformed embedded-JSON-object payloads.

Behavior after the fix:
- Andy → Andy
- C:\Users\file.txt → C:\Users\file.txt (was C:\\Users\\file.txt)
- She said "hi" → She said "hi" (was She said \"hi\")
- URLs and forward-slash paths unchanged.

Test plan:
- Definition with Get String → Panel(Andy) → Concat(Hello , value, !) → Context Print. Solve via Hops. Expect: Hello Andy!.
- Definition with Get File Path or Get String → Context Print. Default value: C:\Users\public\test.gh. Solve via Hops. Expect: output equals input with single backslashes preserved.
- Definition with Get String → Context Print. Default value: She said "hi". Solve. Expect: output equals input, no escape sequences.
- Sanity: existing Hops workflows with non-special string values continue to work unchanged.

Changelog: ### Fixed entry under [0.16.29] covering both halves of the fix.