### PR TITLE
Fix interleaved child process logging in rhino.compute and add per-po…

### DIFF
--- a/src/compute.geometry/Logging.cs
+++ b/src/compute.geometry/Logging.cs
@@ -1,11 +1,28 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using Serilog;
+using Serilog.Core;
 using Serilog.Events;
 using Serilog.Templates;
 
 namespace compute.geometry
 {
+    // Reads a mutable static port at log-event time so the prefix can switch from "CG " to
+    // "CG NNNN" mid-run — useful for standalone launches where the port isn't known until
+    // Kestrel binds (default 5000). When _port == 0, the property is not added and the
+    // output template's {Port} placeholder renders empty.
+    sealed class DynamicPortEnricher : ILogEventEnricher
+    {
+        static int _port;
+        public static void SetPort(int port) => _port = port;
+        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory factory)
+        {
+            int port = _port;
+            if (port > 0)
+                logEvent.AddPropertyIfAbsent(factory.CreateProperty("Port", port));
+        }
+    }
+
     static class Logging
     {
         static bool _enabled = false;
@@ -15,7 +32,11 @@ namespace compute.geometry
         /// <summary>
         /// Initialises globally-shared logger.
         /// </summary>
-        public static void Init()
+        /// <param name="port">Port this child is listening on if already known at init time
+        /// (i.e. passed via -port:N from rhino.compute). Pass 0 when the port is unknown — the
+        /// prefix renders without a port, and a later call to <see cref="DynamicPortEnricher.SetPort"/>
+        /// (typically from the Kestrel ApplicationStarted callback) will start populating it.</param>
+        public static void Init(int port = 0)
         {
             if (_enabled)
                 return;
@@ -28,10 +49,24 @@ namespace compute.geometry
             var limit = Config.LogRetainDays;
             var level = Config.Debug ? LogEventLevel.Debug : LogEventLevel.Information;
 
+            // Seed the dynamic enricher when port is already known; otherwise leave it at 0 so the
+            // {Port} placeholder renders empty until something calls DynamicPortEnricher.SetPort.
+            if (port > 0)
+                DynamicPortEnricher.SetPort(port);
+
             var logger = new LoggerConfiguration()
                 .MinimumLevel.Is(level)
                 .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning)
-                .WriteTo.Console(outputTemplate: "CG {Port} [{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}")
+                .Enrich.With(new DynamicPortEnricher())
+                // ANSI theme embeds colors as escape sequences in the output text so they
+                // survive rhino.compute's stdout pipe (the default SystemConsoleTheme.Literate
+                // uses Console.ForegroundColor, a Win32 API that has no effect on a piped handle).
+                // applyThemeToRedirectedOutput: true is required because the sink otherwise
+                // swaps our theme for ConsoleTheme.None whenever Console.IsOutputRedirected.
+                .WriteTo.Console(
+                    outputTemplate: "CG {Port} [{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}",
+                    theme: Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme.Literate,
+                    applyThemeToRedirectedOutput: true)
                 .WriteTo.File(new ExpressionTemplate("CG {Port} [{@t:HH:mm:ss} {@l:u3}] {@m}\n{@x}"), path, rollingInterval: RollingInterval.Day, retainedFileCountLimit: limit);
 
             Log.Logger = logger.CreateLogger();

--- a/src/compute.geometry/Program.cs
+++ b/src/compute.geometry/Program.cs
@@ -21,7 +21,11 @@ namespace compute.geometry
         static void Main(string[] args)
         {
             Config.Load();
-            Logging.Init();
+            // Pre-scan for -port so it can be enriched into every log line. Full arg parsing
+            // happens below; this is just a peek so the logger has the port from the very first
+            // line. Without it, "Logging to ..." and "Registering idle span ..." would land in
+            // the console with an empty port column.
+            Logging.Init(FindPortArg(args));
 
             ParseCommandLineArgs(args);
 
@@ -70,6 +74,28 @@ namespace compute.geometry
                 })
                 .UseSerilog(Log.Logger)
                 .Build();
+
+            // When the port wasn't passed via -port:N (standalone launches), Kestrel binds to
+            // its default URL once the host starts. Pull the bound port out of IServerAddressesFeature
+            // and push it into DynamicPortEnricher so subsequent log lines render as "CG NNNN".
+            var lifetime = (Microsoft.Extensions.Hosting.IHostApplicationLifetime)
+                host.Services.GetService(typeof(Microsoft.Extensions.Hosting.IHostApplicationLifetime));
+            lifetime?.ApplicationStarted.Register(() =>
+            {
+                var server = (Microsoft.AspNetCore.Hosting.Server.IServer)
+                    host.Services.GetService(typeof(Microsoft.AspNetCore.Hosting.Server.IServer));
+                var addresses = server?.Features.Get<Microsoft.AspNetCore.Hosting.Server.Features.IServerAddressesFeature>();
+                if (addresses == null) return;
+                foreach (var url in addresses.Addresses)
+                {
+                    if (Uri.TryCreate(url, UriKind.Absolute, out var uri) && uri.Port > 0)
+                    {
+                        DynamicPortEnricher.SetPort(uri.Port);
+                        break;
+                    }
+                }
+            });
+
             Shutdown.StartTimer(host);
             host.Run();
 
@@ -137,6 +163,17 @@ namespace compute.geometry
                         break;
                 }
             }
+        }
+
+        static int FindPortArg(string[] args)
+        {
+            foreach (var arg in args)
+            {
+                SplitArg(arg, out string key, out string value);
+                if (key == "port" && int.TryParse(value, out int port))
+                    return port;
+            }
+            return 0;
         }
 
         static void SplitArg(string arg, out string key, out string value)

--- a/src/compute.geometry/Startup.cs
+++ b/src/compute.geometry/Startup.cs
@@ -7,6 +7,7 @@ namespace compute.geometry
 {
     public class Startup
     {
+
         //https://github.com/mcneel/rhino/blob/e1192835cbf03f662d0cf857ee9239b84109eeed/src4/rhino4/Plug-ins/RhinoCodePlugins/RhinoCodePlugin/AssemblyInfo.cs
         static readonly Guid s_rhinoCodePluginId = new Guid("c9cba87a-23ce-4f15-a918-97645c05cde7");
 
@@ -107,6 +108,7 @@ namespace compute.geometry
             if (Config.LoadGrasshopper)
             {
                 Log.Information("(3/4) Loading grasshopper");
+
 #if LINUX
                 var ghpath = RhinoInside.Resolver.RhinoSystemDirectory + "/Plug-ins/Grasshopper/GrasshopperPlugin.rhp";
                 var pluginresult = Rhino.PlugIns.PlugIn.LoadPlugIn(ghpath, out Guid ghid);
@@ -120,6 +122,30 @@ namespace compute.geometry
                     runheadless.Invoke(pluginObject, null);
 #endif
 
+                // Only emit the "Loaded assembly: X" burst when we're running as a child of
+                // rhino.compute (signalled by the -childof:<pid> arg, which populates
+                // Shutdown.ParentProcesses). In that mode CreateNoWindow=true on the child
+                // ProcessStartInfo suppresses Grasshopper's native "* Loading X assembly..."
+                // chatter, so re-emitting via Serilog restores per-plugin visibility through
+                // the CG-prefixed channel. When launched standalone, the native chatter is
+                // already visible on the console and adding our burst would just duplicate it,
+                // so we skip the enumeration.
+                bool launchedByRhinoCompute = Shutdown.ParentProcesses != null && Shutdown.ParentProcesses.Count > 0;
+                if (launchedByRhinoCompute)
+                {
+                    try
+                    {
+                        foreach (var lib in Grasshopper.Instances.ComponentServer.Libraries)
+                        {
+                            if (lib != null && !string.IsNullOrEmpty(lib.Name))
+                                Log.Information("Loaded assembly: {Name}", lib.Name);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Warning(ex, "Unable to enumerate Grasshopper libraries after RunHeadless");
+                    }
+                }
             }
             else
             {

--- a/src/rhino.compute/ComputeChildren.cs
+++ b/src/rhino.compute/ComputeChildren.cs
@@ -246,8 +246,40 @@ namespace rhino.compute
         {
             var startInfo = CreateComputeStartInfo(pathToCompute, port);
             process = Process.Start(startInfo);
+            if (process != null)
+            {
+                // Lines emitted by the child's Serilog (ANSI theme) already begin with an
+                // escape sequence and a "CG {port} [...]" prefix — pass them through verbatim.
+                // Anything else (Grasshopper's raw Console.WriteLine output during plugin load,
+                // the occasional stderr write) is wrapped via _childRawLogger so it picks up
+                // the same prefix, colors, and port enrichment as a normal CG line.
+                void ReEmit(string line)
+                {
+                    if (line == null) return;
+                    if (line.Length > 0 && (line[0] == '\x1B' || line.StartsWith("CG ", StringComparison.Ordinal)))
+                        Console.WriteLine(line);
+                    else
+                        _childRawLogger.ForContext("Port", port).Information("{Line:l}", line);
+                }
+                process.OutputDataReceived += (s, e) => ReEmit(e.Data);
+                process.ErrorDataReceived  += (s, e) => ReEmit(e.Data);
+                process.BeginOutputReadLine();
+                process.BeginErrorReadLine();
+            }
             return WaitForChildProcess(process, port);
         }
+
+        // Wraps raw stdout/stderr lines from child processes (e.g. Grasshopper's plugin-load
+        // progress messages written via Console.WriteLine, which bypass the child's Serilog
+        // entirely) so they render with the same "CG {Port} [...]" prefix, color theme, and
+        // port enrichment as Serilog-emitted CG lines. Uses applyThemeToRedirectedOutput so
+        // colors still emit if rhino.compute itself ever runs with redirected stdout.
+        static readonly ILogger _childRawLogger = new LoggerConfiguration()
+            .WriteTo.Console(
+                outputTemplate: "CG {Port} [{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}",
+                theme: Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme.Literate,
+                applyThemeToRedirectedOutput: true)
+            .CreateLogger();
 
         // Returns the first port >= 6001 that is not in usedPorts and is not already listening.
         // Returns 0 if no free port is found.
@@ -271,6 +303,21 @@ namespace rhino.compute
         {
             var startInfo = new ProcessStartInfo(pathToCompute);
             startInfo.EnvironmentVariables["ASPNETCORE_HOSTINGSTARTUPASSEMBLIES"] = "";
+            // Redirect the child's stdout/stderr so we can re-emit them through the parent's
+            // single Console.Out. Multiple children writing to the OS stdout handle directly
+            // would interleave at byte level (visible when SpawnCount >= 3 spawns siblings in
+            // parallel); routing through a single in-process TextWriter serializes the writes.
+            // The child's own "CG ..." Serilog prefix is preserved.
+            startInfo.UseShellExecute = false;
+            startInfo.RedirectStandardOutput = true;
+            startInfo.RedirectStandardError = true;
+            // Sever inheritance of rhino.compute's console handle. Without this, native code
+            // inside the child (notably Grasshopper's plugin loader) writes its "Loading X
+            // assembly..." progress straight to the inherited CONOUT$ — which bypasses our
+            // stdout pipe and ends up shared between all children, causing byte-level
+            // interleaving on the parent's console. Forcing CreateNoWindow makes those native
+            // writes either fall through to STD_OUTPUT_HANDLE (our pipe) or no-op.
+            startInfo.CreateNoWindow = true;
             var rhinoProcess = Process.GetCurrentProcess();
             string args = $"-port:{port} -childof:{rhinoProcess.Id}";
             Log.Information("Starting compute.geometry instance on port {Port}", port);

--- a/src/rhino.compute/Program.cs
+++ b/src/rhino.compute/Program.cs
@@ -107,7 +107,9 @@ requests while the child processes are launching.")]
             .MinimumLevel.Is(level)
             .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning)
             .Filter.ByExcluding("RequestPath in ['/healthcheck', '/favicon.ico']")
-            .WriteTo.Console(outputTemplate: "RC  [{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}")
+            .WriteTo.Console(
+                outputTemplate: "RC  [{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}",
+                theme: Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme.Literate)
             .WriteTo.File(new ExpressionTemplate("RC   [{@t:HH:mm:ss} {@l:u3}] {@m}\n{@x}"), path, rollingInterval: RollingInterval.Day, retainedFileCountLimit: limit);
             Log.Logger = loggerConfig.CreateLogger();
 


### PR DESCRIPTION
…rt prefix

When `rhino.compute` is launched with `--childcount` ≥ 3, the console output from
  its child `compute.geometry` processes interleaved at byte level (e.g. `GCG 6002 [...]`
  where the start of one line collided with another). Children inherited the parent's
  console handle, and concurrent writes from sibling processes raced at the OS layer.

  This PR routes all child output through `rhino.compute`'s single in-process console
  writer so writes can't interleave, and adds a port-aware prefix so the source child of
  each line is identifiable.

  ## Changes

  - **`rhino.compute/ComputeChildren.cs`** — child `ProcessStartInfo` now sets
    `RedirectStandardOutput`/`RedirectStandardError` + `CreateNoWindow=true`. New
    `OutputDataReceived`/`ErrorDataReceived` handlers either pass through child Serilog
    lines (detected by leading ANSI escape) or wrap raw lines via a new internal
    `_childRawLogger` that re-applies the `CG {Port} [...]` template.
  - **`compute.geometry/Logging.cs`** — new `DynamicPortEnricher : ILogEventEnricher`
    reads a mutable static so the prefix can flip from `"CG "` to `"CG NNNN"` mid-run.
    Console sink switched to `AnsiConsoleTheme.Literate` with
    `applyThemeToRedirectedOutput: true` so colors survive the parent's stdout pipe.
  - **`rhino.compute/Program.cs`** — Console sink switched to matching ANSI theme so
    RC and CG lines share the same color palette.
  - **`compute.geometry/Program.cs`** — pre-scans args for `-port:N` before
    `Logging.Init` so the port is enriched from the first log line. Adds an
    `IHostApplicationLifetime.ApplicationStarted` callback that pulls the bound port
    from `IServerAddressesFeature` and updates `DynamicPortEnricher` — covers the
    standalone case where Kestrel's default (5000) isn't known until after host start.
  - **`compute.geometry/Startup.cs`** — after `RunHeadless()` completes, enumerates
    `Grasshopper.Instances.ComponentServer.Libraries` and emits a `"Loaded assembly: X"`
    line per plugin through Serilog. Gated on `Shutdown.ParentProcesses?.Count > 0` so
    the burst is only emitted under rhino.compute (where Grasshopper's native CONOUT$
    chatter is suppressed by `CreateNoWindow=true`); skipped in standalone runs where
    the raw chatter is still visible and would duplicate.

  ## Behavior notes

  - **Via rhino.compute (production):** clean, color-coded, per-port-prefixed output.
    Per-plugin `Loaded assembly: X` lines fill in for Grasshopper's native chatter
    that gets suppressed when `CreateNoWindow=true` severs console inheritance.
  - **Standalone `compute.geometry.exe`:** unchanged Grasshopper chatter visible on
    the developer's console; `CG ` prefix until Kestrel binds, then `CG 5000`; no
    `Loaded assembly: X` duplication.
  - **Per-process `.txt` log files:** unchanged path/rolling/retention, now also
    include the port in the prefix and the `Loaded assembly: X` lines (Serilog
    fan-out). Raw Grasshopper chatter still never reaches the file sink.
  - **No change to Luis's parallel-spawn warmup behavior** — children still launch in
    parallel for fast startup; the fix is at the I/O layer, not the spawn scheduler.

  ## Test plan

  - [ ] `rhino.compute --childcount 1`: clean RC + CG 6001 output, no interleaving.
  - [ ] `rhino.compute --childcount 4`: clean RC + CG 6001-6004 output, no interleaving,
        no fused-word artifacts (e.g. no `GCG`).
  - [ ] Per-child `log-compute-geometry-*.txt` files show port in prefix and
        `Loaded assembly:` lines.
  - [ ] `compute.geometry.exe` launched standalone (debugger): raw Grasshopper
        chatter visible, no `Loaded assembly:` duplicate, `CG ` → `CG 5000` after
        `Now listening on http://localhost:5000`.
  - [ ] Colors render correctly in modern terminals; degrade to visible escapes on
        old terminals (acceptable).