### PR TITLE
Add --load-children-sequentially flag for memory-constrained VMs

### DIFF
--- a/src/rhino.compute/ComputeChildren.cs
+++ b/src/rhino.compute/ComputeChildren.cs
@@ -35,6 +35,16 @@ namespace rhino.compute
         /// </summary>
         public static bool SpawnOnStartup { get; set; } = false;
 
+        /// <summary>
+        /// When true, post-bootstrap child spawns run one at a time on a single background
+        /// task — each LaunchCompute() call blocks until that child's port is open before the
+        /// next is started. When false (default), the (SpawnCount-1) post-bootstrap spawns are
+        /// dispatched as separate Task.Run calls and run in parallel.
+        /// Sequential is the escape hatch for memory-constrained VMs where parallel
+        /// Rhino+Grasshopper loads can exhaust RAM.
+        /// </summary>
+        public static bool LoadChildrenSequentially { get; set; } = false;
+
         /// <summary>Port that rhino.compute is running on</summary>
         public static int ParentPort { get; set; } = 5000;
         /// <summary>
@@ -134,8 +144,26 @@ namespace rhino.compute
             {
                 spawnTasksToQueue = Math.Max(0, SpawnCount - (_computeProcesses.Count + _pendingSpawnPorts.Count));
             }
-            for (int i = 0; i < spawnTasksToQueue; i++)
-                System.Threading.Tasks.Task.Run(() => LaunchCompute());
+            if (spawnTasksToQueue > 0)
+            {
+                if (LoadChildrenSequentially)
+                {
+                    // Single background task that drains the queue serially. LaunchCompute()
+                    // blocks until the spawned child's port opens, so each iteration waits for
+                    // the previous to finish — caps peak Rhino+Grasshopper memory at one extra
+                    // child at a time.
+                    System.Threading.Tasks.Task.Run(() =>
+                    {
+                        for (int i = 0; i < spawnTasksToQueue; i++)
+                            LaunchCompute();
+                    });
+                }
+                else
+                {
+                    for (int i = 0; i < spawnTasksToQueue; i++)
+                        System.Threading.Tasks.Task.Run(() => LaunchCompute());
+                }
+            }
 
             //Log.Information($"Started child process at http://localhost:{activePort} at {DateTime.Now.ToLocalTime()}");
             return ($"http://localhost:{activePort}", activePort);

--- a/src/rhino.compute/Program.cs
+++ b/src/rhino.compute/Program.cs
@@ -81,6 +81,12 @@ requests while the child processes are launching.")]
              HelpText = "Determines whether to launch a child compute.geometry process when rhino.compute gets started")]
             public bool SpawnOnStartup { get; set; }
 
+            [Option("load-children-sequentially",
+             Required = false,
+             Default = false,
+             HelpText = "When set, child compute.geometry processes spawn one at a time (each child finishes loading before the next starts). Default is parallel spawning for faster warmup. Use this on memory-constrained VMs where N parallel Rhino+Grasshopper loads can exhaust RAM.")]
+            public bool LoadChildrenSequentially { get; set; }
+
             [Option("timeout",
               Required = false,
               HelpText = "Request timeout in seconds (default: 100)")]
@@ -135,6 +141,7 @@ requests while the child processes are launching.")]
                 // Set runtime options
                 ComputeChildren.SpawnCount = o.ChildCount;
                 ComputeChildren.SpawnOnStartup = o.SpawnOnStartup;
+                ComputeChildren.LoadChildrenSequentially = o.LoadChildrenSequentially;
                 ComputeChildren.ChildIdleSpan = new System.TimeSpan(0, 0, o.IdleSpanSeconds);
                 ComputeChildren.RhinoSysDir = o.RhinoSysDir;
                 int parentProcessId = o.ChildOf;
@@ -189,6 +196,7 @@ requests while the child processes are launching.")]
             Log.Debug("  Timeout = {Timeout}", FormatTimeout(Config.ReverseProxyRequestTimeout));
             Log.Debug("  Child Count = {ChildCount}", ComputeChildren.SpawnCount.ToString());
             Log.Debug("  Spawn Children At Startup = {SpawnChild}", ComputeChildren.SpawnOnStartup.ToString());
+            Log.Debug("  Load Children Sequentially = {LoadSequentially}", ComputeChildren.LoadChildrenSequentially.ToString());
             bool loadGrasshopper = true;
             loadGrasshopper = Boolean.TryParse(Environment.GetEnvironmentVariable("RHINO_COMPUTE_LOAD_GRASSHOPPER"), out var loadGH) ? loadGH : true;
             Log.Debug("  Load Grasshopper = {LoadGH}", loadGrasshopper.ToString());


### PR DESCRIPTION
## Summary

  Adds an opt-in CLI flag to rhino.compute that serializes the post-bootstrap child-process
  spawn loop. Default behavior is unchanged (parallel spawning, fast warmup); the flag is
  an escape hatch for VMs where N parallel Rhino+Grasshopper loads can exhaust RAM.

  ## Changes

  - **`rhino.compute/Program.cs`** — new `[Option("load-children-sequentially")]` flag,
    wired into `ComputeChildren.LoadChildrenSequentially`. Logged in the startup
    `Config:` block alongside the other flags.
  - **`rhino.compute/ComputeChildren.cs`** — new static `LoadChildrenSequentially`
    (default `false`). In `GetComputeServerBaseUrl`, the post-bootstrap warmup now
    branches: when `false`, dispatches the existing `Task.Run` per spawn (parallel);
    when `true`, dispatches a single `Task.Run` that loops through `LaunchCompute()`
    calls — each blocks until its child's port opens before the next is started.

  ## Behavior notes

  - First child (bootstrap) is still synchronous in both modes, so the first request is
    served just as fast.
  - With the flag set, pool warmup takes `~3-4s × (N-1)` instead of `~3-4s` total.
    Peak RAM during warmup is capped at "one extra child loading" rather than "N-1
    children loading at once".
  - No change to per-request behavior, the proxy handler, or any other flag.

  ## Test plan

  - [ ] Without the flag (`--childcount 4`): console shows all four children starting up
        in parallel after the first one is ready (same as before).
  - [ ] With `--load-children-sequentially` (`--childcount 4 --load-children-sequentially`):
        console shows children 2, 3, 4 starting one at a time, each `Loaded assembly:`
        burst grouped together by port before the next child begins.
  - [ ] `Config:` block in rhino.compute's startup logs shows
        `Load Children Sequentially = True/False` matching the flag.
  - [ ] Compare peak memory usage in Task Manager between the two modes on a real
        configuration (e.g. `--childcount 6`) and confirm the sequential mode caps
        at lower peak RAM.