### PR TITLE
Build CI artifacts for both Windows and Linux via matrix

### DIFF
--- a/.github/workflows/workflow_ci.yml
+++ b/.github/workflows/workflow_ci.yml
@@ -52,12 +52,25 @@ jobs:
           files: src/**
 
   build_compute:
-    name: build compute
-    runs-on: ubuntu-latest
+    name: build compute (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
     needs: [check_workflow, check_src]
     if: ${{ needs.check_src.outputs.any_changed == 'true' || needs.check_workflow.outputs.any_changed == 'true' }}
+    # Matrix over both runners so the csproj OS-conditionals produce a Windows-targeted build
+    # on windows-latest (net10.0-windows + win-x64 + web.config) and a Linux-targeted build on
+    # ubuntu-latest (net10.0 + linux-x64). The "rhino.compute" artifact name is preserved for
+    # the Windows variant since it's the historical deliverable that downstream consumers
+    # (e.g. the VM bootstrap script) reference by that exact name.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            artifact_name: rhino.compute
+          - os: ubuntu-latest
+            artifact_name: rhino.compute-linux-x64
     steps:
       - name: checkout
         uses: actions/checkout@v6
@@ -68,6 +81,9 @@ jobs:
           dotnet-version: '10.0.x'
       - name: revision
         id: revision
+        # shell: bash forces git-bash on windows-latest so ${GITHUB_SHA::9} substring works on
+        # both hosts (default shell on windows-latest is pwsh, which doesn't recognise this).
+        shell: bash
         run: |
           echo "::set-output name=revision::${GITHUB_SHA::9}"
       - name: revision number
@@ -82,4 +98,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: src/dist
-          name: rhino.compute
+          name: ${{ matrix.artifact_name }}


### PR DESCRIPTION
## Summary

  Restore Windows artifact production from CI. The `build_compute` job was switched to
  `ubuntu-latest` in commit `5982d8f` ("Use setup-dotnet action to install the full
  dotnet sdk including windows bits") with the intent of cross-compiling, but the csproj
  OS-conditionals key on the build host's OS — so on Ubuntu, both projects evaluate their
  Linux branches and the published artifact ends up Linux-targeted, missing `web.config`
  and other Windows-specific bits. Bootstrap scripts that consume the `rhino.compute`
  artifact on Windows VMs were broken as a result.

  ## Changes

  - **`.github/workflows/workflow_ci.yml`** — `build_compute` job converted to a matrix
    over `windows-latest` and `ubuntu-latest`. Each runner produces a separate artifact:
    - `rhino.compute` (Windows, preserves historical name for downstream consumers)
    - `rhino.compute-linux-x64` (Linux variant, new)
  - `shell: bash` added to the revision step so `${GITHUB_SHA::9}` works on Windows too
    (default shell on `windows-latest` is pwsh).
  - `fail-fast: false` so one runner's failure doesn't cancel the other build.

  ## Behavior notes

  - No csproj changes needed — the existing `$([MSBuild]::IsOSPlatform(...))` conditionals
    already produce the correct per-host output. The issue was solely that the Windows
    branch wasn't being exercised by CI.
  - `workflow_package.yml` (the Linux `.deb`/`.rpm` pipeline that publishes to S3) is
    untouched and continues to build its own self-contained Linux artifacts with explicit
    `-r linux-x64`/`-r linux-arm64`.
  - Artifact uploads stay gated by `github.ref == 'refs/heads/9.x'` for both runners, so
    PR builds don't consume storage.

  ## Test plan

  - [ ] Push to a feature branch, confirm both matrix jobs run and complete green.
  - [ ] Merge to `9.x`, confirm both artifacts appear under
        https://api.github.com/repos/mcneel/compute.rhino3d/actions/artifacts.
  - [ ] Download `rhino.compute` artifact, confirm `web.config` is present and the
        VM bootstrap script succeeds.
  - [ ] Download `rhino.compute-linux-x64` artifact, confirm Linux-targeted DLLs.