### PR TITLE
Add global exception handler, timing-safe API-key compare, and unauth…

### DIFF
--- a/src/compute.geometry/ApiKeyMiddleware.cs
+++ b/src/compute.geometry/ApiKeyMiddleware.cs
@@ -1,5 +1,7 @@
 using Microsoft.AspNetCore.Http;
 using Serilog;
+using System.Security.Cryptography;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace compute.geometry
@@ -47,8 +49,14 @@ namespace compute.geometry
                 return;
             }
 
-            var apiKey = Config.ApiKey;
-            if (!apiKey.Equals(extractedApiKey))
+            // Timing-safe comparison. String.Equals exits early on the first byte that
+            // differs, which leaks key-prefix information to an attacker measuring response
+            // times across many requests. FixedTimeEquals walks both buffers fully every
+            // time, so the per-byte work is constant regardless of where they differ.
+            // (Length difference still short-circuits — that's not a meaningful leak.)
+            var providedBytes = Encoding.UTF8.GetBytes(extractedApiKey.ToString());
+            var configuredBytes = Encoding.UTF8.GetBytes(Config.ApiKey);
+            if (!CryptographicOperations.FixedTimeEquals(providedBytes, configuredBytes))
             {
                 Log.Warning("401 rejecting {Method} {Path}: {HeaderName} header does not match server's configured key",
                     method, context.Request.Path, APIKEYNAME);

--- a/src/compute.geometry/Logging.cs
+++ b/src/compute.geometry/Logging.cs
@@ -59,6 +59,12 @@ namespace compute.geometry
             var logger = new LoggerConfiguration()
                 .MinimumLevel.Is(level)
                 .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning)
+                // Silence ASP.NET Core's built-in "An unhandled exception has occurred while
+                // executing the request." log emitted by ExceptionHandlerMiddleware. Our own
+                // app.UseExceptionHandler handler logs a categorized, formatted version with
+                // the same stack trace, so without this override the same exception shows up
+                // twice on the console.
+                .MinimumLevel.Override("Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware", LogEventLevel.Fatal)
                 .Enrich.With(new DynamicPortEnricher())
                 .WriteTo.Console(outputTemplate: "CG {Port} [{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}")
                 .WriteTo.File(new ExpressionTemplate("CG {Port} [{@t:HH:mm:ss} {@l:u3}] {@m}\n{@x}"), path, rollingInterval: RollingInterval.Day, retainedFileCountLimit: limit);

--- a/src/compute.geometry/Program.cs
+++ b/src/compute.geometry/Program.cs
@@ -28,6 +28,14 @@ namespace compute.geometry
             // warnings would land with an empty port column.
             Logging.Init(FindPortArg(args));
 
+            // Loud warning if the server is starting unauthenticated. The ApiKeyMiddleware
+            // only wires up when Config.ApiKey is non-empty, so a missing key means every
+            // POST endpoint accepts any caller. Operators sometimes don't realize the env
+            // var didn't propagate (running process predates the setx, IIS app pool not
+            // recycled, etc.) — this surfaces the problem at startup instead of silently.
+            if (string.IsNullOrWhiteSpace(Config.ApiKey))
+                Log.Warning("RHINO_COMPUTE_KEY is not set; API authentication is disabled. All endpoints are open to any caller.");
+
             ParseCommandLineArgs(args);
 
 #if DEBUG

--- a/src/compute.geometry/Startup.cs
+++ b/src/compute.geometry/Startup.cs
@@ -1,6 +1,10 @@
 ﻿using System;
+using System.Linq;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
 using Serilog;
 
 namespace compute.geometry
@@ -29,6 +33,41 @@ namespace compute.geometry
         public void Configure(IApplicationBuilder app)
         {
             RhinoCoreStartup();
+
+            // Global exception handler. Sits at the very top of the pipeline so it catches
+            // anything thrown by downstream middleware or endpoint handlers. Logs the
+            // exception via Serilog, then returns a structured JSON 500 response. Stack
+            // traces are only included when Config.Debug is true so production builds
+            // don't leak implementation details to callers.
+            app.UseExceptionHandler(errApp => errApp.Run(async ctx =>
+            {
+                var ex = ctx.Features.Get<IExceptionHandlerFeature>()?.Error;
+
+                string category = ex == null ? null
+                    : ex.GetType().Name.Contains("Json") ? "Malformed JSON received"
+                    : ex is FormatException ? "Invalid format"
+                    : ex is ArgumentException ? "Invalid argument"
+                    : ex.GetType().Name;
+                string message = ex == null
+                    ? "Unknown error"
+                    : (category != null ? $"{category}: {ex.Message}" : ex.Message);
+
+                Log.Error(ex, "Unhandled exception during {Method} {Path}: {Category}",
+                    ctx.Request.Method, ctx.Request.Path, category ?? "Unknown");
+
+                ctx.Response.StatusCode = StatusCodes.Status500InternalServerError;
+                ctx.Response.ContentType = "application/json";
+
+                string[] stack = ex?.StackTrace?
+                    .Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(l => l.TrimStart())
+                    .ToArray() ?? Array.Empty<string>();
+
+                object body = Config.Debug
+                    ? new { error = "Internal Server Error", message, stackTrace = stack }
+                    : new { error = "Internal Server Error", message = "An unexpected error occurred. Check server logs for details." };
+                await ctx.Response.WriteAsync(JsonConvert.SerializeObject(body));
+            }));
 
             app.UseRouting();
             app.UseCors();

--- a/src/rhino.compute/ApiKeyMiddleware.cs
+++ b/src/rhino.compute/ApiKeyMiddleware.cs
@@ -2,6 +2,8 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Serilog;
+using System.Security.Cryptography;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace rhino.compute
@@ -25,9 +27,14 @@ namespace rhino.compute
                 return;
             }
 
-            var apiKey = Config.ApiKey;
-
-            if (!apiKey.Equals(extractedApiKey))
+            // Timing-safe comparison. String.Equals exits early on the first byte that
+            // differs, which leaks key-prefix information to an attacker measuring response
+            // times across many requests. FixedTimeEquals walks both buffers fully every
+            // time, so the per-byte work is constant regardless of where they differ.
+            // (Length difference still short-circuits — that's not a meaningful leak.)
+            var providedBytes = Encoding.UTF8.GetBytes(extractedApiKey.ToString());
+            var configuredBytes = Encoding.UTF8.GetBytes(Config.ApiKey);
+            if (!CryptographicOperations.FixedTimeEquals(providedBytes, configuredBytes))
             {
                 Log.Warning("401 rejecting {Method} {Path}: {HeaderName} header does not match server's configured key",
                     context.Request.Method, context.Request.Path, APIKEYNAME);

--- a/src/rhino.compute/Program.cs
+++ b/src/rhino.compute/Program.cs
@@ -129,6 +129,12 @@ namespace rhino.compute
             var loggerConfig = new LoggerConfiguration()
                 .MinimumLevel.Is(level)
                 .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning)
+                // Silence ASP.NET Core's built-in "An unhandled exception has occurred while
+                // executing the request." log emitted by ExceptionHandlerMiddleware. Our own
+                // app.UseExceptionHandler handler logs a categorized, formatted version with
+                // the same stack trace, so without this override the same exception shows up
+                // twice on the console.
+                .MinimumLevel.Override("Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware", LogEventLevel.Fatal)
                 .Filter.ByExcluding("RequestPath in ['/healthcheck', '/favicon.ico']")
                 .WriteTo.Console(outputTemplate: "RC  [{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}")
                 .WriteTo.File(new ExpressionTemplate("RC   [{@t:HH:mm:ss} {@l:u3}] {@m}\n{@x}"), path, rollingInterval: RollingInterval.Day, retainedFileCountLimit: limit);
@@ -165,6 +171,15 @@ namespace rhino.compute
             }
 
             Log.Information($"Rhino compute started at {DateTime.Now.ToLocalTime()}");
+
+            // Loud warning if the proxy is starting unauthenticated. The ApiKeyMiddleware
+            // only wires up when Config.ApiKey is non-empty, so a missing key means every
+            // endpoint accepts any caller. Operators sometimes don't realize the env var
+            // didn't propagate (running process predates the setx, IIS app pool not
+            // recycled, etc.) — this surfaces the problem at startup instead of silently.
+            if (string.IsNullOrWhiteSpace(Config.ApiKey))
+                Log.Warning("RHINO_COMPUTE_KEY is not set; API authentication is disabled. All endpoints are open to any caller.");
+
             Log.Debug($"Config:");
             Log.Debug("  Max Request Size = {RequestSize}", (Config.MaxRequestSize / 1024.0 / 1024.0).ToString("F2") + " MB");
             Log.Debug("  Timeout = {Timeout}", FormatTimeout(Config.ReverseProxyRequestTimeout));

--- a/src/rhino.compute/Startup.cs
+++ b/src/rhino.compute/Startup.cs
@@ -1,9 +1,13 @@
 ﻿namespace rhino.compute
 {
     using System;
+    using System.Linq;
     using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Diagnostics;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.DependencyInjection;
     using Serilog;
+    using System.Text.Json;
 
     public class Startup
     {
@@ -22,6 +26,41 @@
 
         public void Configure(IApplicationBuilder app)
         {
+            // Global exception handler. Sits at the very top of the pipeline so it catches
+            // anything thrown by downstream middleware or endpoint handlers. Logs the
+            // exception via Serilog, then returns a structured JSON 500 response. Stack
+            // traces are only included when Config.Debug is true so production builds
+            // don't leak implementation details to callers.
+            app.UseExceptionHandler(errApp => errApp.Run(async ctx =>
+            {
+                var ex = ctx.Features.Get<IExceptionHandlerFeature>()?.Error;
+
+                string category = ex == null ? null
+                    : ex.GetType().Name.Contains("Json") ? "Malformed JSON received"
+                    : ex is FormatException ? "Invalid format"
+                    : ex is ArgumentException ? "Invalid argument"
+                    : ex.GetType().Name;
+                string message = ex == null
+                    ? "Unknown error"
+                    : (category != null ? $"{category}: {ex.Message}" : ex.Message);
+
+                Log.Error(ex, "Unhandled exception during {Method} {Path}: {Category}",
+                    ctx.Request.Method, ctx.Request.Path, category ?? "Unknown");
+
+                ctx.Response.StatusCode = StatusCodes.Status500InternalServerError;
+                ctx.Response.ContentType = "application/json";
+
+                string[] stack = ex?.StackTrace?
+                    .Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(l => l.TrimStart())
+                    .ToArray() ?? Array.Empty<string>();
+
+                object body = Config.Debug
+                    ? new { error = "Internal Server Error", message, stackTrace = stack }
+                    : new { error = "Internal Server Error", message = "An unexpected error occurred. Check server logs for details." };
+                await ctx.Response.WriteAsync(JsonSerializer.Serialize(body));
+            }));
+
             app.UseSerilogRequestLogging();
             app.UseRouting();
             app.UseCors();


### PR DESCRIPTION
…enticated startup warning

## Summary

  Continues the post-fresh-review hardening wave with three bundled middleware
  improvements, plus log-output polish that came out of testing them:

  1. **Global exception handler** in both servers — uncaught exceptions previously
     returned raw stack traces in the response body. Now wrapped in a Serilog-logged
     structured JSON 500, with a human-friendly category prefix on the message.
  2. **Timing-safe API-key comparison** — both `ApiKeyMiddleware` files used
     `String.Equals`, which short-circuits on the first differing byte and leaks
     key-prefix information through response-time measurements. Replaced with
     `CryptographicOperations.FixedTimeEquals` on UTF-8 byte arrays.
  3. **Startup warning when no API key is configured** — `ApiKeyMiddleware` only
     wires up when `Config.ApiKey` is non-empty, so a missing/unset env var means
     every endpoint accepts any caller. A `Log.Warning` now fires at startup so
     operators don't run unauthenticated by accident (e.g. when an env var didn't
     propagate to a long-running process, or an IIS app pool didn't recycle after
     `setx`).

  ## Changes

  ### Exception handler

  - **`src/compute.geometry/Startup.cs`** + **`src/rhino.compute/Startup.cs`** —
    `UseExceptionHandler(...)` at the very top of `Configure` so it catches
    anything thrown by downstream middleware or endpoint handlers. Returns
    `application/json` 500 with `{ error, message }` and (when `Config.Debug` is
    true) `stackTrace` as an array of frames so JSON viewers render each frame
    on its own line. The message includes a category prefix matched from the
    exception type — "Malformed JSON received: ..." for anything whose type name
    contains "Json", "Invalid format: ..." for FormatException, "Invalid
    argument: ..." for ArgumentException, otherwise the bare type name. Release
    builds emit only the canned "An unexpected error occurred..." with no stack
    trace. compute.geometry uses Newtonsoft (already referenced); rhino.compute
    uses System.Text.Json (built into ASP.NET Core).
  - **`src/compute.geometry/Logging.cs`** + **`src/rhino.compute/Program.cs`** —
    added `.MinimumLevel.Override("Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware", LogEventLevel.Fatal)`
    to the Serilog config. ASP.NET Core's built-in `ExceptionHandlerMiddleware`
    logs every unhandled exception at Error level via its own logger category
    *before* invoking the configured handler — without this override, the same
    exception+stack-trace shows up twice on the console.
  - The `Log.Error(ex, ...)` template inside each handler is shaped as
    `"Unhandled exception during {Method} {Path}: {Category}"`. Passing just the
    category (not the full message) into the template avoids duplicating the
    exception message text, since Serilog's automatic exception formatting
    already emits "ExceptionType: ExceptionMessage" plus the stack trace on the
    lines that follow.

  ### Timing-safe API key

  - **`src/compute.geometry/ApiKeyMiddleware.cs`** +
    **`src/rhino.compute/ApiKeyMiddleware.cs`** — swap `String.Equals` for
    `CryptographicOperations.FixedTimeEquals` with UTF-8 byte conversion.
    Comment inline explains the timing-attack rationale (`String.Equals`'s
    short-circuit-on-first-difference leaks key-prefix info to an attacker
    measuring response times).

  ### Startup warning

  - **`src/compute.geometry/Program.cs`** + **`src/rhino.compute/Program.cs`** —
    `Log.Warning("RHINO_COMPUTE_KEY is not set; API authentication is disabled.
    All endpoints are open to any caller.")` immediately after the startup
    banner. Only fires when `Config.ApiKey` is null/empty.

  ## Behavior notes

  - Exception handler sits at the very top of the middleware pipeline (before
    `UseRouting`, before any auth) so it can catch literally anything downstream.
  - Stack traces only appear in HTTP responses when `Config.Debug` is true; the
    full exception is always logged via Serilog regardless.
  - `FixedTimeEquals` requires same-length buffers — it returns false
    immediately on length mismatch, which is fine because length isn't sensitive
    for API keys.
  - The startup warning is at Warning level so it shows in the console (yellow)
    without firing operator pages. If you want to require a key in production,
    grep logs for "API authentication is disabled".

  ## Test plan

  - [x] All projects build clean.
  - [x] Start server with no `RHINO_COMPUTE_KEY`: see the WRN line at startup.
  - [x] Start with key set: WRN does NOT appear; auth check works on POST.
  - [x] Wrong key on POST: 401 with the same WRN line as before (no change to
        caller behavior; only internal comparison timing changed).
  - [x] Trigger an uncaught exception (POST `/grasshopper` with body `not json`):
        compute.geometry returns JSON 500 with `{ error, message: "Malformed JSON
        received: ...", stackTrace: [...] }`. Single ERR log line on the console
        showing the category, followed by Serilog's exception auto-format with
        the type+message+stack trace.
  - [x] Same test through the rhino.compute proxy: same JSON 500 response; the
        child compute.geometry's console shows the single ERR line (no duplicate
        framework log).