### PR TITLE
Drop unused NuGet dependencies and orphaned config.

### DIFF
--- a/src/compute.geometry/compute.geometry.csproj
+++ b/src/compute.geometry/compute.geometry.csproj
@@ -43,7 +43,6 @@
     <PackageReference Include="Serilog.Expressions" Version="3.4.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-    <PackageReference Include="System.Management" Version="8.0.0" />
     <PackageReference Include="System.Runtime.Caching" Version="8.0.0" />
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.0" />
   </ItemGroup>

--- a/src/rhino.compute/appsettings.json
+++ b/src/rhino.compute/appsettings.json
@@ -1,18 +1,3 @@
 {
-    "Serilog": {
-        "Using": [ "SeriLog.Sinks.Console", "Serilog.Sinks.File"],
-        "MinimumLevel": {
-            "Default": "Information",
-            "Override": {
-                "Microsoft": "Information",
-                "Microsoft.AspNetCore": "Warning",
-                "System": "Warning"
-            }
-        },
-        "Enrich": [ "FromLogContext", "WithMachineName", "WithThreadId" ],
-        "Properties": {
-            "Application": "Rhino.Compute"
-        }
-    },
     "AllowedHosts": "*"
 }

--- a/src/rhino.compute/rhino.compute.csproj
+++ b/src/rhino.compute/rhino.compute.csproj
@@ -26,12 +26,7 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
-    <PackageReference Include="Serilog.Enrichers.Environment" Version="2.2.0" />
-    <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
     <PackageReference Include="Serilog.Expressions" Version="3.4.1" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0" />
-    <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
 ## Summary

  Slim the project tree by removing PackageReferences that nothing in our code
  references. Net effect: six fewer transitive dependency graphs to restore and
  build, no behavior change.

  ## Changes

  ### compute.geometry

  - Removed `System.Management 8.0.0` — no `using System.Management;`, no
    `ManagementObject` / WMI usage anywhere. Process monitoring uses the
    built-in `System.Diagnostics.Process`.
  - **Investigated and kept** `Microsoft.Windows.Compatibility 8.0.0`. Build
    succeeded without it, but a Hops round-trip solve destabilized the worker
    ~15 seconds later with a `WebSocketSharp.WebSocketException`. Rhino's
    licensing system (Cloud Zoo) uses WebSockets to phone home and is brought
    up by `RhinoInside.Resolver.Initialize()`; the most likely cause is that
    the licensing path relies on something in the meta-package's transitive
    surface (e.g. `System.Configuration`, `Microsoft.Win32.Registry`) at
    runtime via reflection or dynamic loading. Restored as-is.

  ### rhino.compute

  - Removed `Serilog.Exceptions 8.4.0` — no `WithExceptionDetails()` calls.
  - Removed `Serilog.Sinks.Async 1.5.0` — no `.WriteTo.Async(...)`; sinks are
    wired directly.
  - Removed `Serilog.Settings.Configuration 3.4.0` — no
    `ReadFrom.Configuration(...)` call exists. The `appsettings.json` declared
    Serilog config but nothing read it.
  - Removed `Serilog.Enrichers.Environment 2.2.0` — only referenced via the
    `WithMachineName` string in the dead `appsettings.json` block.
  - Removed `System.Net.Http 4.3.4` — built into the .NET 8 framework, the
    explicit package reference was a polyfill holdover from older .NET Standard
    targets.
  - Cleaned up `appsettings.json` — removed the orphaned Serilog block that
    declared enrichers and sinks that no code reads. File now contains only
    `{"AllowedHosts": "*"}`.

  ### Hops

  No changes — every PackageReference and assembly Reference is in active use.

  ## Test plan

  - [x] All three projects build clean (warning count unchanged from before).
  - [x] Smoke test pass 1 (System.Management + Serilog/HTTP cleanup): rhino.compute
        starts normally, valid `POST /grasshopper` solves, malformed JSON returns
        the categorized 500, 401 paths still log correctly, file sink still
        writes log-rhino-compute-*.txt under Config.LogPath.
  - [x] Smoke test pass 2 (Microsoft.Windows.Compatibility removed): build clean,
        basic POST succeeds, **but** a Hops geometry round-trip tipped over with
        a WebSocketSharp exception ~15s later (Rhino licensing path) → restored.
  - [x] Repeat full Hops geometry round-trip test with the final state to
        confirm regression is gone.