### PR TITLE
Validate URL scheme via Uri parsing instead of StartsWith()

### DIFF
--- a/src/compute.geometry/GrasshopperDefinition.cs
+++ b/src/compute.geometry/GrasshopperDefinition.cs
@@ -94,7 +94,7 @@ namespace compute.geometry
 
                 rc = Construct(archive);
                 rc.CacheKey = url;
-                rc.IsLocalFileDefinition = !url.StartsWith("http", StringComparison.OrdinalIgnoreCase) && File.Exists(url);
+                rc.IsLocalFileDefinition = !UrlGuard.IsWebUrl(url) && File.Exists(url);
             }
             if (cache)
             {
@@ -707,7 +707,7 @@ namespace compute.geometry
                 return null;
             }
 
-            if (url.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+            if (UrlGuard.IsWebUrl(url))
             {
                 // UrlGuard validates scheme + optional private-IP block, then streams the
                 // response with a size cap from Config.MaxRequestSize. HttpClientHelper.Client

--- a/src/compute.geometry/UrlGuard.cs
+++ b/src/compute.geometry/UrlGuard.cs
@@ -22,6 +22,18 @@ namespace compute.geometry
     //     a malicious server hosting a multi-GB body can't exhaust memory
     static class UrlGuard
     {
+        // Lightweight classifier: true only if the string is a well-formed ABSOLUTE
+        // http/https URL. Prefer this over a StartsWith("http") prefix check, which is
+        // both too loose and not a real parse — it accepts look-alikes like "httpfoo://"
+        // or a relative path named "httpdocs/model.gh". Used to decide whether a path
+        // should be fetched over HTTP vs treated as a local file. (Validate() enforces the
+        // same scheme rule but throws on violation; use IsWebUrl where a bool fits.)
+        public static bool IsWebUrl(string url)
+        {
+            return Uri.TryCreate(url, UriKind.Absolute, out var uri)
+                && (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps);
+        }
+
         // Throws an exception describing the violation if the URL is malformed,
         // uses a non-http(s) scheme, or (when Config.BlockPrivateUrls is true)
         // resolves to a private/loopback IP. Returns normally on success.

--- a/src/hops/HopsComponent.cs
+++ b/src/hops/HopsComponent.cs
@@ -602,7 +602,7 @@ namespace Hops
         {
             if (String.IsNullOrEmpty(row.SourceName) || String.IsNullOrEmpty(row.SourcePath))
                 return;
-            if (row.SourcePath.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+            if (RemoteDefinition.IsWebUrl(row.SourcePath))
             {
                 try
                 {


### PR DESCRIPTION
## Summary
  - Replaced fragile `StartsWith("http", OrdinalIgnoreCase)` URL checks with proper
    absolute-URL + scheme validation. A prefix match accepts look-alikes
    (`httpfoo://...`, or a relative path literally named `httpdocs/model.gh`) and
    never confirms the string is a well-formed URL.
  - Added `UrlGuard.IsWebUrl(string)` in compute.geometry (`Uri.TryCreate` +
    `Scheme == http/https`), mirroring the existing `RemoteDefinition.IsWebUrl` in
    Hops. Complements `UrlGuard.Validate()` (which throws) by returning a bool for
    classification.
  - Converted the three call sites: `GrasshopperDefinition.cs` (the web-vs-local
    dispatch in `ArchiveFromUrl`, and the `IsLocalFileDefinition` classification)
    and `HopsComponent.cs` (now reuses `RemoteDefinition.IsWebUrl`).
  - No API or behavior change for valid URLs; malformed/relative inputs are now
    classified more strictly (correctly treated as non-web). The SSRF fetch path
    remains backstopped by `UrlGuard.Validate()`.

  ## Test plan
  - [x] compute.geometry and Hops build clean
  - [x] `/io` → pointer → `/grasshopper` round-trip with an http(s) definition URL
  - [x] Local-file definition load still classifies as local