### PR TITLE
Validate JSON-array shape on geometry POST and URL-fetch paths

### DIFF
--- a/src/compute.geometry/DataCache.cs
+++ b/src/compute.geometry/DataCache.cs
@@ -235,7 +235,11 @@ namespace compute.geometry
                     // and a Config.MaxRequestSize cap to the outbound fetch.
                     string cacheString = UrlGuard.GetStringAsync(url, Config.MaxRequestSize).Result;
                     object data = string.IsNullOrWhiteSpace(cacheString) ? null : Newtonsoft.Json.JsonConvert.DeserializeObject(cacheString);
-                    var ja = data as Newtonsoft.Json.Linq.JArray;
+                    // Expect the URL to return a non-empty JSON array. Throw a descriptive
+                    // error instead of a bare NullReferenceException/IndexOutOfRange when the
+                    // fetched content is the wrong shape (this is an external-data boundary).
+                    if (!(data is Newtonsoft.Json.Linq.JArray ja) || ja.Count == 0)
+                        throw new InvalidOperationException($"Expected URL '{url}' to return a non-empty JSON array.");
                     jtoken = ja[0];
                 }
 

--- a/src/compute.geometry/GeometryEndPoint.cs
+++ b/src/compute.geometry/GeometryEndPoint.cs
@@ -374,8 +374,22 @@ namespace compute.geometry
                 return;
             }
 
-            object data = string.IsNullOrWhiteSpace(jsonString) ? null : JsonConvert.DeserializeObject(jsonString);
-            var ja = data as Newtonsoft.Json.Linq.JArray;
+            // The POST body is expected to be a JSON array of arguments. Deserialize to the
+            // expected shape and reject anything else (non-array JSON, malformed JSON, or an
+            // empty body) with a 400 — otherwise a null `ja` would NullReference below. This
+            // is a client-input boundary, so a bad shape is a 400, not a 500.
+            Newtonsoft.Json.Linq.JArray ja = null;
+            if (!string.IsNullOrWhiteSpace(jsonString))
+            {
+                try { ja = JsonConvert.DeserializeObject(jsonString) as Newtonsoft.Json.Linq.JArray; }
+                catch (Newtonsoft.Json.JsonException) { ja = null; }
+            }
+            if (ja == null)
+            {
+                context.Response.StatusCode = 400;
+                await context.Response.WriteAsync("Request body must be a JSON array.");
+                return;
+            }
             string resultString = null;
             if (multiple && ja.Count > 1)
             {


### PR DESCRIPTION
## Summary
  - Hardened the two parameterless `JsonConvert.DeserializeObject(...)` sites in
    compute.geometry that assume the parsed JSON is an array and would otherwise
    `NullReferenceException`/`IndexOutOfRange` on the wrong shape. (Note: this is a
    robustness fix, not a type-confusion/RCE fix — Newtonsoft's parameterless
    overload uses `TypeNameHandling.None` and no global `DefaultSettings` enables it,
    so no arbitrary-type instantiation was ever possible.)
  - `GeometryEndPoint.cs` (POST handler): an empty body, non-array JSON (`{}`, a
    scalar), or malformed JSON now returns a clean **400 "Request body must be a JSON
    array."** instead of NRE-ing into a 500. This is a client-input boundary, so a bad
    shape is a 400. Valid arrays are unchanged, including an empty array `[]` (still a
    valid, non-null `JArray` that flows through as before).
  - `DataCache.cs` (server-side URL fetch, no HttpContext to return a 400): if the
    fetched URL returns a non-array or empty array, it now throws a descriptive
    `InvalidOperationException("Expected URL '<url>' to return a non-empty JSON array.")`
    instead of a bare null-ref, so the global exception handler can surface a
    meaningful message.

  ## Test plan
  - [x] Valid JSON-array geometry POST returns 200 with the correct result
  - [x] Empty body, `{}`, scalar JSON, and malformed JSON all return 400
  - [x] Empty array `[]` still returns 200 (passthrough preserved — no regression)
  - [ ] DataCache URL-fetch wrong-shape path (not exercised; small self-contained guard)