### PR TITLE
Drop underscore prefixes from rhino.compute and compute.geometry

### DIFF
--- a/src/compute.geometry/ApiKeyMiddleware.cs
+++ b/src/compute.geometry/ApiKeyMiddleware.cs
@@ -22,12 +22,12 @@ namespace compute.geometry
     // no headers). Auth-sensitive work happens on POST (e.g. /grasshopper).
     public class ApiKeyMiddleware
     {
-        const string APIKEYNAME = "RhinoComputeKey";
-        readonly RequestDelegate _next;
+        const string API_KEY_NAME = "RhinoComputeKey";
+        readonly RequestDelegate next;
 
         public ApiKeyMiddleware(RequestDelegate next)
         {
-            _next = next;
+            this.next = next;
         }
 
         public async Task InvokeAsync(HttpContext context)
@@ -36,14 +36,14 @@ namespace compute.geometry
             var method = context.Request.Method;
             if (HttpMethods.IsGet(method) || HttpMethods.IsOptions(method))
             {
-                await _next(context);
+                await next(context);
                 return;
             }
 
-            if (!context.Request.Headers.TryGetValue(APIKEYNAME, out var extractedApiKey))
+            if (!context.Request.Headers.TryGetValue(API_KEY_NAME, out var extractedApiKey))
             {
                 Log.Warning("401 rejecting {Method} {Path}: missing {HeaderName} header",
-                    method, context.Request.Path, APIKEYNAME);
+                    method, context.Request.Path, API_KEY_NAME);
                 context.Response.StatusCode = 401;
                 await context.Response.WriteAsync("Api Key was not provided.");
                 return;
@@ -59,13 +59,13 @@ namespace compute.geometry
             if (!CryptographicOperations.FixedTimeEquals(providedBytes, configuredBytes))
             {
                 Log.Warning("401 rejecting {Method} {Path}: {HeaderName} header does not match server's configured key",
-                    method, context.Request.Path, APIKEYNAME);
+                    method, context.Request.Path, API_KEY_NAME);
                 context.Response.StatusCode = 401;
                 await context.Response.WriteAsync("Unauthorized client.");
                 return;
             }
 
-            await _next(context);
+            await next(context);
         }
     }
 }

--- a/src/compute.geometry/Config.cs
+++ b/src/compute.geometry/Config.cs
@@ -77,7 +77,7 @@ namespace compute.geometry
         /// </summary>
         public static bool LoadGrasshopper { get; private set; }
 
-        public static string[] GetDeprecationWarnings() => _warnings.ToArray();
+        public static string[] GetDeprecationWarnings() => warnings.ToArray();
 
         /// <summary>
         /// RHINO_COMPUTE_DEBUG: enables debug logging (defaults to true in DEBUG).
@@ -106,10 +106,10 @@ namespace compute.geometry
 #endif
             Debug = GetEnvironmentVariable(RHINO_COMPUTE_DEBUG, Debug);
 
-            foreach (var name in _ignored)
+            foreach (var name in ignored)
             {
                 if (!string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(name)))
-                    _warnings.Add($"Ignoring deprecated {name} environment variable");
+                    warnings.Add($"Ignoring deprecated {name} environment variable");
             }
         }
 
@@ -132,9 +132,9 @@ namespace compute.geometry
         const string COMPUTE_LOG_PATH = "COMPUTE_LOG_PATH";
         const string COMPUTE_LOG_RETAIN_DAYS = "COMPUTE_LOG_RETAIN_DAYS";
 
-        readonly static string[] _ignored = new string[] { "COMPUTE_BACKEND_PORT" };
+        readonly static string[] ignored = new string[] { "COMPUTE_BACKEND_PORT" };
 
-        readonly static List<string> _warnings = new List<string>();
+        readonly static List<string> warnings = new List<string>();
 
         static T GetEnvironmentVariable<T>(string name, T defaultValue, string deprecatedName = null)
         {
@@ -144,7 +144,7 @@ namespace compute.geometry
             {
                 value = Environment.GetEnvironmentVariable(deprecatedName);
                 if (!string.IsNullOrWhiteSpace(value))
-                    _warnings.Add($"{deprecatedName} is deprecated; use {name} instead");
+                    warnings.Add($"{deprecatedName} is deprecated; use {name} instead");
             }
 
             if (string.IsNullOrWhiteSpace(value))
@@ -162,7 +162,7 @@ namespace compute.geometry
                 if (int.TryParse(value, out int result))
                     return (T)(object)result;
 
-                _warnings.Add($"{name} set to '{value}'; unable to parse as integer");
+                warnings.Add($"{name} set to '{value}'; unable to parse as integer");
                 return defaultValue;
             }
 
@@ -171,7 +171,7 @@ namespace compute.geometry
                 if (long.TryParse(value, out long result))
                     return (T)(object)result;
 
-                _warnings.Add($"{name} set to '{value}'; unable to parse as long");
+                warnings.Add($"{name} set to '{value}'; unable to parse as long");
                 return defaultValue;
             }
 

--- a/src/compute.geometry/DataCache.cs
+++ b/src/compute.geometry/DataCache.cs
@@ -275,13 +275,13 @@ namespace compute.geometry
 
         // Two separate MemoryCache instances with deliberately different eviction policies:
         //
-        //  - _definitionCache: stores parsed GrasshopperDefinitions. NEVER evicts under
+        //  - definitionCache: stores parsed GrasshopperDefinitions. NEVER evicts under
         //    memory pressure. Clients send a /io request, receive a Pointer in the
         //    response, then reference that Pointer in subsequent /grasshopper calls so
         //    they don't have to re-upload the full definition. Evicting an entry here
         //    breaks every pointer-based client holding that Pointer.
         //
-        //  - _resultsCache: stores serialized solve outputs AND URL-fetched JSON data.
+        //  - resultsCache: stores serialized solve outputs AND URL-fetched JSON data.
         //    LRU-evicts under host memory pressure (configured via
         //    PhysicalMemoryLimitPercentage = Config.CachePhysicalLimitPercent, default 70%).
         //    On cache miss, both kinds of entry are re-derivable: a missing solve result

--- a/src/compute.geometry/GeometryEndPoint.cs
+++ b/src/compute.geometry/GeometryEndPoint.cs
@@ -16,19 +16,19 @@ namespace compute.geometry
 {
     class GeometryEndPoint
     {
-        static List<GeometryEndPoint> _allEndPoints;
+        static List<GeometryEndPoint> allEndPoints;
         public static IEnumerable<GeometryEndPoint> AllEndPoints
         {
             get
             {
-                if(_allEndPoints==null)
+                if(allEndPoints==null)
                 {
-                    _allEndPoints = new List<GeometryEndPoint>();
+                    allEndPoints = new List<GeometryEndPoint>();
                     foreach (string nameSpace in new string[] { "Rhino.Geometry", "Rhino.Geometry.Intersect" })
                     {
                         foreach (var endpoint in CreateEndpoints(typeof(Rhino.RhinoApp).Assembly, nameSpace))
                         {
-                            _allEndPoints.Add(endpoint);
+                            allEndPoints.Add(endpoint);
                         }
                     }
 
@@ -44,13 +44,13 @@ namespace compute.geometry
                                 foreach (var endpoint in GeometryEndPoint.Create(customEndpoint.Item2))
                                 {
                                     endpoint.UpdatePath(customEndpoint.Item1);
-                                    _allEndPoints.Add(endpoint);
+                                    allEndPoints.Add(endpoint);
                                 }
                             }
                         }
                     }
                 }
-                return _allEndPoints;
+                return allEndPoints;
             }
         }
 
@@ -74,18 +74,18 @@ namespace compute.geometry
         }
 
 
-        Type _classType;
-        ConstructorInfo[] _constructors;
-        MethodInfo[] _methods;
-        string _path;
+        Type classType;
+        ConstructorInfo[] constructors;
+        MethodInfo[] methods;
+        string path;
 
         public string Path
         {
-            get { return _path; }
+            get { return path; }
             private set
             {
-                _path = value;
-                PathURL = _path.ToLowerInvariant();
+                path = value;
+                PathURL = path.ToLowerInvariant();
             }
         }
 
@@ -93,27 +93,27 @@ namespace compute.geometry
 
         public void UpdatePath(string basePath)
         {
-            int index = _path.LastIndexOf('/');
+            int index = path.LastIndexOf('/');
             if( index > 0 )
             {
                 basePath = basePath.Replace('.', '/').ToLowerInvariant();
-                Path = basePath + _path.Substring(index);
+                Path = basePath + path.Substring(index);
             }
         }
 
         private GeometryEndPoint(Type classType, ConstructorInfo[] constructors)
         {
-            _classType = classType;
-            _constructors = constructors;
-            string basepath = _classType.FullName.Replace('.', '/');
+            this.classType = classType;
+            this.constructors = constructors;
+            string basepath = classType.FullName.Replace('.', '/');
             Path = basepath + "/New";
         }
 
         private GeometryEndPoint(Type classType, MethodInfo[] methods, bool explicitPath)
         {
-            _classType = classType;
-            _methods = methods;
-            string basepath = _classType.FullName.Replace('.', '/');
+            this.classType = classType;
+            this.methods = methods;
+            string basepath = classType.FullName.Replace('.', '/');
             string funcname = methods[0].Name;
             if (funcname.StartsWith("get_"))
                 funcname = "Get" + funcname.Substring("get_".Length);
@@ -159,7 +159,7 @@ namespace compute.geometry
         protected GeometryEndPoint(string path, Type classType)
         {
             Path = path;
-            _classType = classType;
+            this.classType = classType;
         }
 
         public static List<GeometryEndPoint> Create(Type t)
@@ -243,15 +243,15 @@ namespace compute.geometry
             var sb = new System.Text.StringBuilder("<!DOCTYPE html><html><body>");
             sb.AppendLine($"<H1>{funcname}</H1>");
             sb.AppendLine("<p>");
-            if (_methods != null)
+            if (methods != null)
             {
-                foreach (var method in _methods)
+                foreach (var method in methods)
                 {
                     var inParams = new List<Tuple<Type, string>>();
                     var outParams = new List<Tuple<Type, string>>();
                     {
                         if (!method.IsStatic)
-                            inParams.Add(new Tuple<Type, string>(_classType, "self"));
+                            inParams.Add(new Tuple<Type, string>(classType, "self"));
                         if (method.ReturnType != typeof(void))
                             outParams.Add(new Tuple<Type, string>(method.ReturnType, ""));
                         foreach (var parameter in method.GetParameters())
@@ -277,7 +277,7 @@ namespace compute.geometry
                                     }
                                 }
                                 if (!isConst)
-                                    outParams.Add(new Tuple<Type, string>(_classType, ""));
+                                    outParams.Add(new Tuple<Type, string>(classType, ""));
                             }
                         }
                     }
@@ -305,11 +305,11 @@ namespace compute.geometry
                     sb.AppendLine(")<br>");
                 }
             }
-            if (_constructors != null)
+            if (constructors != null)
             {
-                foreach (var constructor in _constructors)
+                foreach (var constructor in constructors)
                 {
-                    sb.Append($"{_classType.Name} {funcname}(");
+                    sb.Append($"{classType.Name} {funcname}(");
                     var parameters = constructor.GetParameters();
                     for (int pi = 0; pi < parameters.Length; pi++)
                     {
@@ -472,12 +472,12 @@ namespace compute.geometry
         string HandlePostHelper(Newtonsoft.Json.Linq.JArray ja, Dictionary<string, string> returnModifiers)
         {
             int tokenCount = ja == null ? 0 : ja.Count;
-            if (_methods != null)
+            if (methods != null)
             {
                 JsonSerializer serializer = new JsonSerializer();
                 serializer.Converters.Add(new ArchivableDictionaryResolver());
                 int methodIndex = -1;
-                foreach (var method in _methods)
+                foreach (var method in methods)
                 {
                     methodIndex++;
                     int paramCount = method.GetParameters().Length;
@@ -496,7 +496,7 @@ namespace compute.geometry
                         int currentJa = 0;
                         if (!method.IsStatic)
                         {
-                            invokeObj = ToObjectHelper(ja[currentJa++], _classType, null);
+                            invokeObj = ToObjectHelper(ja[currentJa++], classType, null);
                         }
 
                         int outParamCount = 0;
@@ -565,7 +565,7 @@ namespace compute.geometry
                         }
                         catch (Exception)
                         {
-                            if (methodIndex < (_methods.Count() - 1))
+                            if (methodIndex < (methods.Count() - 1))
                                 continue;
                             throw;
                         }
@@ -618,11 +618,11 @@ namespace compute.geometry
                 }
             }
 
-            if (_constructors != null)
+            if (constructors != null)
             {
-                for (int k = 0; k < _constructors.Length; k++)
+                for (int k = 0; k < constructors.Length; k++)
                 {
-                    var constructor = _constructors[k];
+                    var constructor = constructors[k];
                     int paramCount = constructor.GetParameters().Length;
                     if (paramCount == tokenCount)
                     {
@@ -636,7 +636,7 @@ namespace compute.geometry
                                 var generics = p[ip].ParameterType.GetGenericArguments();
                                 if (generics == null || generics.Length != 1)
                                 {
-                                    if (_constructors.Length > 0 && p[ip].ParameterType == typeof(Rhino.Geometry.Plane))
+                                    if (constructors.Length > 0 && p[ip].ParameterType == typeof(Rhino.Geometry.Plane))
                                     {
                                         if (ja[ip].Count() < 4)
                                         {
@@ -765,22 +765,22 @@ namespace compute.geometry
 
     public class GeometryResolver : DefaultContractResolver
     {
-        static int _rhinoVersion = 0;
-        static JsonSerializerSettings _settings;
+        static int rhinoVersion = 0;
+        static JsonSerializerSettings settings;
         public static JsonSerializerSettings Settings(int rhinoVersion)
         {
-            if (_settings == null || rhinoVersion != _rhinoVersion)
+            if (settings == null || rhinoVersion != GeometryResolver.rhinoVersion)
             {
-                _settings = new JsonSerializerSettings { ContractResolver = new GeometryResolver() };
-                _rhinoVersion = rhinoVersion;
+                settings = new JsonSerializerSettings { ContractResolver = new GeometryResolver() };
+                GeometryResolver.rhinoVersion = rhinoVersion;
                 // return V7 ON_Objects for now
                 var options = new Rhino.FileIO.SerializationOptions();
                 options.RhinoVersion = rhinoVersion;
                 options.WriteUserData = true;
-                _settings.Context = new System.Runtime.Serialization.StreamingContext(System.Runtime.Serialization.StreamingContextStates.All, options);
-                _settings.Converters.Add(new ArchivableDictionaryResolver());
+                settings.Context = new System.Runtime.Serialization.StreamingContext(System.Runtime.Serialization.StreamingContextStates.All, options);
+                settings.Converters.Add(new ArchivableDictionaryResolver());
             }
-            return _settings;
+            return settings;
         }
 
         protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)

--- a/src/compute.geometry/GrasshopperDefinition.cs
+++ b/src/compute.geometry/GrasshopperDefinition.cs
@@ -22,29 +22,29 @@ namespace compute.geometry
 {
     class GrasshopperDefinition
     {
-        static Dictionary<string, FileSystemWatcher> _filewatchers;
-        static HashSet<string> _watchedFiles = new HashSet<string>();
-        static uint _watchedFileRuntimeSerialNumber = 1;
+        static Dictionary<string, FileSystemWatcher> filewatchers;
+        static HashSet<string> watchedFiles = new HashSet<string>();
+        static uint watchedFileRuntimeSerialNumber = 1;
         public static uint WatchedFileRuntimeSerialNumber
         {
-            get { return _watchedFileRuntimeSerialNumber; }
+            get { return watchedFileRuntimeSerialNumber; }
         }
         static void RegisterFileWatcher(string path)
         {
-            if (_filewatchers == null)
+            if (filewatchers == null)
             {
-                _filewatchers = new Dictionary<string, FileSystemWatcher>();
+                filewatchers = new Dictionary<string, FileSystemWatcher>();
             }
             if (!File.Exists(path))
                 return;
 
             path = Path.GetFullPath(path);
-            if (_watchedFiles.Contains(path.ToLowerInvariant()))
+            if (watchedFiles.Contains(path.ToLowerInvariant()))
                 return;
 
-            _watchedFiles.Add(path.ToLowerInvariant());
+            watchedFiles.Add(path.ToLowerInvariant());
             string directory = Path.GetDirectoryName(path);
-            if (_filewatchers.ContainsKey(directory) || !Directory.Exists(directory))
+            if (filewatchers.ContainsKey(directory) || !Directory.Exists(directory))
                 return;
 
             var fsw = new FileSystemWatcher(directory);
@@ -57,14 +57,14 @@ namespace compute.geometry
                 NotifyFilters.Security;
             fsw.Changed += Fsw_Changed;
             fsw.EnableRaisingEvents = true;
-            _filewatchers[directory] = fsw;
+            filewatchers[directory] = fsw;
         }
 
         private static void Fsw_Changed(object sender, FileSystemEventArgs e)
         {
             string path = e.FullPath.ToLowerInvariant();
-            if (_watchedFiles.Contains(path))
-                _watchedFileRuntimeSerialNumber++;
+            if (watchedFiles.Contains(path))
+                watchedFileRuntimeSerialNumber++;
         }
 
         public static void LogDebug(string message) { Log.Debug(message); }
@@ -143,20 +143,20 @@ namespace compute.geometry
             }
 
             GrasshopperDefinition rc = new GrasshopperDefinition(definition, null);
-            rc._singularComponent = component;
+            rc.singularComponent = component;
             foreach(var input in component.Params.Input)
             {
-                rc._input[input.NickName] = new InputGroup(input);
+                rc.input[input.NickName] = new InputGroup(input);
             }
             foreach(var output in component.Params.Output)
             {
-                rc._output[output.NickName] = output;
+                rc.output[output.NickName] = output;
             }
             return rc;
         }
         private static void AddInput(IGH_Param param, string name, ref GrasshopperDefinition rc)
         {
-            if (rc._input.ContainsKey(name))
+            if (rc.input.ContainsKey(name))
             {
                 string msg = "Multiple input parameters with the same name were detected. Parameter names must be unique.";
                 rc.HasErrors = true;
@@ -164,11 +164,11 @@ namespace compute.geometry
                 LogError(msg);
             }   
             else
-                rc._input[name] = new InputGroup(param);
+                rc.input[name] = new InputGroup(param);
         }
         private static void AddOutput(IGH_Param param, string name, ref GrasshopperDefinition rc)
         {
-            if (rc._output.ContainsKey(name))
+            if (rc.output.ContainsKey(name))
             {
                 string msg = "Multiple output parameters with the same name were detected. Parameter names must be unique.";
                 rc.HasErrors = true;
@@ -176,7 +176,7 @@ namespace compute.geometry
                 LogError(msg);
             }  
             else
-                rc._output[name] = param;
+                rc.output[name] = param;
         }
 
         private static GrasshopperDefinition Construct(GH_Archive archive)
@@ -291,8 +291,8 @@ namespace compute.geometry
         private GrasshopperDefinition(GH_Document definition, string icon)
         {
             Definition = definition;
-            _iconString = icon;
-            FileRuntimeCacheSerialNumber = _watchedFileRuntimeSerialNumber;
+            iconString = icon;
+            FileRuntimeCacheSerialNumber = watchedFileRuntimeSerialNumber;
         }
 
         public GH_Document Definition { get; }
@@ -301,10 +301,10 @@ namespace compute.geometry
         public bool IsLocalFileDefinition { get; set; } // default: false
         public uint FileRuntimeCacheSerialNumber { get; private set; }
         public string CacheKey { get; set; }
-        string _iconString;
-        GH_Component _singularComponent;
-        Dictionary<string, InputGroup> _input = new Dictionary<string, InputGroup>();
-        Dictionary<string, IGH_Param> _output = new Dictionary<string, IGH_Param>();
+        string iconString;
+        GH_Component singularComponent;
+        Dictionary<string, InputGroup> input = new Dictionary<string, InputGroup>();
+        Dictionary<string, IGH_Param> output = new Dictionary<string, IGH_Param>();
         public List<string> ErrorMessages = new List<string>();
 
         public GH_Path GetPath(string p)
@@ -318,7 +318,7 @@ namespace compute.geometry
         {
             foreach (var tree in values)
             {
-                if( !_input.TryGetValue(tree.ParamName, out var inputGroup))
+                if( !input.TryGetValue(tree.ParamName, out var inputGroup))
                 {
                     continue;
                 }
@@ -427,7 +427,7 @@ namespace compute.geometry
             }
         }
 
-        static readonly System.Collections.Concurrent.ConcurrentDictionary<Type, MethodInfo> _assignContextualDataTreeMethods = new System.Collections.Concurrent.ConcurrentDictionary<Type, MethodInfo>();
+        static readonly System.Collections.Concurrent.ConcurrentDictionary<Type, MethodInfo> assignContextualDataTreeMethods = new System.Collections.Concurrent.ConcurrentDictionary<Type, MethodInfo>();
 
         void BuildAndAssignContextualTree<T>(IGH_ContextualParameter param,
                                              Resthopper.IO.DataTree<ResthopperObject> tree,
@@ -440,7 +440,7 @@ namespace compute.geometry
                 foreach (var restobj in entree.Value)
                     inputTree.Add(convert(restobj), path);
             }
-            var method = _assignContextualDataTreeMethods.GetOrAdd(
+            var method = assignContextualDataTreeMethods.GetOrAdd(
                 param.GetType(),
                 t => t.GetMethod("AssignContextualDataTree"));
             method?.Invoke(param, new object[] { inputTree });
@@ -485,7 +485,7 @@ namespace compute.geometry
 
             LogRuntimeMessages(Definition.ActiveObjects(), outputSchema);
 
-            foreach (var kvp in _output)
+            foreach (var kvp in output)
             {
                 var param = kvp.Value;
                 if (param == null)
@@ -606,13 +606,13 @@ namespace compute.geometry
 
         public string GetIconAsString()
         {
-            if (!string.IsNullOrWhiteSpace(_iconString))
-                return _iconString;
+            if (!string.IsNullOrWhiteSpace(iconString))
+                return iconString;
 
             System.Drawing.Bitmap bmp = null;
-            if (_singularComponent!=null)
+            if (singularComponent!=null)
             {
-                bmp = _singularComponent.Icon_24x24;
+                bmp = singularComponent.Icon_24x24;
             }
 
             if (bmp!=null)
@@ -622,7 +622,7 @@ namespace compute.geometry
                     bmp.Save(ms, System.Drawing.Imaging.ImageFormat.Png);
                     byte[] bytes = ms.ToArray();
                     string rc = Convert.ToBase64String(bytes);
-                    _iconString = rc;
+                    iconString = rc;
                     return rc;
                 }
             }
@@ -637,8 +637,8 @@ namespace compute.geometry
             var inputs = new List<InputParamSchema>();
             var outputs = new List<IoParamSchema>();
 
-            var sortedInputs = from x in _input orderby x.Value.Param.Attributes.Pivot.Y select x;
-            var sortedOutputs = from x in _output orderby x.Value.Attributes.Pivot.Y select x;
+            var sortedInputs = from x in input orderby x.Value.Param.Attributes.Pivot.Y select x;
+            var sortedOutputs = from x in output orderby x.Value.Attributes.Pivot.Y select x;
 
             foreach (var i in sortedInputs)
             {
@@ -655,7 +655,7 @@ namespace compute.geometry
                     Minimum = i.Value.GetMinimum(),
                     Maximum = i.Value.GetMaximum(),
                 };
-                if (_singularComponent != null)
+                if (singularComponent != null)
                 {
                     inputSchema.Description = i.Value.Param.Description;
                     if (i.Value.Param.Access == GH_ParamAccess.item)
@@ -676,9 +676,9 @@ namespace compute.geometry
                 });
             }
 
-            string description = _singularComponent == null ?
+            string description = singularComponent == null ?
                 Definition.Properties.Description :
-                _singularComponent.Description;
+                singularComponent.Description;
 
             return new IoResponseSchema
             {
@@ -777,14 +777,14 @@ namespace compute.geometry
 
         class InputGroup
         {
-            object _default = null;
+            object defaultValue = null;
             public InputGroup(IGH_Param param)
             {
                 Param = param;
 
                 param.ClearData();
                 param.CollectData();
-                _default = SerializeDataTree(param.VolatileData, param.Name);
+                defaultValue = SerializeDataTree(param.VolatileData, param.Name);
             }
 
             public IGH_Param Param { get; }
@@ -835,7 +835,7 @@ namespace compute.geometry
 
             public object GetDefault()
             {
-                return _default;
+                return defaultValue;
             }
 
             public double? GetMinimum()
@@ -917,10 +917,10 @@ namespace compute.geometry
 
             public bool AlreadySet(Resthopper.IO.DataTree<ResthopperObject> tree)
             {
-                if (_tree == null)
+                if (this.tree == null)
                     return false;
 
-                var oldDictionary = _tree.InnerTree;
+                var oldDictionary = this.tree.InnerTree;
                 var newDictionary = tree.InnerTree;
 
                 if (!oldDictionary.Keys.SequenceEqual(newDictionary.Keys))
@@ -945,10 +945,10 @@ namespace compute.geometry
 
             public void CacheTree(Resthopper.IO.DataTree<ResthopperObject> tree)
             {
-                _tree = tree;
+                this.tree = tree;
             }
 
-            Resthopper.IO.DataTree<ResthopperObject> _tree;
+            Resthopper.IO.DataTree<ResthopperObject> tree;
         }
     }
 }

--- a/src/compute.geometry/HttpClientHelper.cs
+++ b/src/compute.geometry/HttpClientHelper.cs
@@ -11,19 +11,19 @@ namespace compute.geometry
     /// </summary>
     static class HttpClientHelper
     {
-        static HttpClient _client;
+        static HttpClient client;
         public static HttpClient Client
         {
             get
             {
-                if (_client == null)
+                if (client == null)
                 {
-                    _client = new HttpClient(new HttpClientHandler
+                    client = new HttpClient(new HttpClientHandler
                     {
                         AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
                     });
                 }
-                return _client;
+                return client;
             }
         }
     }

--- a/src/compute.geometry/IO/GhPath.cs
+++ b/src/compute.geometry/IO/GhPath.cs
@@ -85,18 +85,18 @@ namespace Resthopper.IO
     {
 
         public DataTree() {
-            _tree = new Dictionary<string, List<T>>();
+            tree = new Dictionary<string, List<T>>();
             //_GhPathIndexer = new Dictionary<int, GhPath>();
         }
 
-        private Dictionary<string, List<T>> _tree;
+        private Dictionary<string, List<T>> tree;
         public string ParamName { get; set; }
         //Dictionary<int, GhPath> _GhPathIndexer;
 
 
         public Dictionary<string, List<T>> InnerTree {
-            get { return _tree; }
-            set { _tree = value; }
+            get { return tree; }
+            set { tree = value; }
         }
 
         //public string ParamName { get; set; }
@@ -104,41 +104,41 @@ namespace Resthopper.IO
 /*
         public ICollection<string> Keys {
             get {
-                return ((IDictionary<string, List<T>>)_tree).Keys;
+                return ((IDictionary<string, List<T>>)tree).Keys;
             }
         }
 
         public ICollection<List<T>> Values {
             get {
-                return ((IDictionary<string, List<T>>)_tree).Values;
+                return ((IDictionary<string, List<T>>)tree).Values;
             }
         }
 
         public int Count {
             get {
-                return ((IDictionary<string, List<T>>)_tree).Count;
+                return ((IDictionary<string, List<T>>)tree).Count;
             }
         }
 
         public bool IsReadOnly {
             get {
-                return ((IDictionary<string, List<T>>)_tree).IsReadOnly;
+                return ((IDictionary<string, List<T>>)tree).IsReadOnly;
             }
         }
 */
         public List<T> this[string key] {
             get {
-                return ((IDictionary<string, List<T>>)_tree)[key];
+                return ((IDictionary<string, List<T>>)tree)[key];
             }
 
             set {
-                ((IDictionary<string, List<T>>)_tree)[key] = value;
+                ((IDictionary<string, List<T>>)tree)[key] = value;
             }
         }
 
         public bool Contains(T item) {
 
-            foreach (var list in _tree.Values) {
+            foreach (var list in tree.Values) {
                 if (list.Contains(item)) {
                     return true;
                 }
@@ -152,10 +152,10 @@ namespace Resthopper.IO
 
         public void Append(List<T> items, string GhPath) {
 
-            if (!_tree.ContainsKey(GhPath)) {
-                _tree.Add(GhPath, new List<T>());
+            if (!tree.ContainsKey(GhPath)) {
+                tree.Add(GhPath, new List<T>());
             }
-            _tree[GhPath].AddRange(items);
+            tree[GhPath].AddRange(items);
             //_GhPathIndexer.Add(item.Index, GhPath);
         }
 
@@ -164,55 +164,55 @@ namespace Resthopper.IO
         }
 
         public void Append(T item, string GhPath) {
-            if (!_tree.ContainsKey(GhPath)) {
-                _tree.Add(GhPath, new List<T>());
+            if (!tree.ContainsKey(GhPath)) {
+                tree.Add(GhPath, new List<T>());
             }
-            _tree[GhPath].Add(item);
+            tree[GhPath].Add(item);
             //_GhPathIndexer.Add(item.Index, GhPath);
         }
 
         public bool ContainsKey(string key) {
-            return ((IDictionary<string, List<T>>)_tree).ContainsKey(key);
+            return ((IDictionary<string, List<T>>)tree).ContainsKey(key);
         }
 
         public void Add(string key, List<T> value) {
-            ((IDictionary<string, List<T>>)_tree).Add(key, value);
+            ((IDictionary<string, List<T>>)tree).Add(key, value);
         }
 
         public bool Remove(string key) {
-            return ((IDictionary<string, List<T>>)_tree).Remove(key);
+            return ((IDictionary<string, List<T>>)tree).Remove(key);
         }
 
         public bool TryGetValue(string key, out List<T> value) {
-            return ((IDictionary<string, List<T>>)_tree).TryGetValue(key, out value);
+            return ((IDictionary<string, List<T>>)tree).TryGetValue(key, out value);
         }
 
         public void Add(KeyValuePair<string, List<T>> item) {
-            ((IDictionary<string, List<T>>)_tree).Add(item);
+            ((IDictionary<string, List<T>>)tree).Add(item);
         }
 
         public void Clear() {
-            ((IDictionary<string, List<T>>)_tree).Clear();
+            ((IDictionary<string, List<T>>)tree).Clear();
         }
 
         public bool Contains(KeyValuePair<string, List<T>> item) {
-            return ((IDictionary<string, List<T>>)_tree).Contains(item);
+            return ((IDictionary<string, List<T>>)tree).Contains(item);
         }
 
         public void CopyTo(KeyValuePair<string, List<T>>[] array, int arrayIndex) {
-            ((IDictionary<string, List<T>>)_tree).CopyTo(array, arrayIndex);
+            ((IDictionary<string, List<T>>)tree).CopyTo(array, arrayIndex);
         }
 
         public bool Remove(KeyValuePair<string, List<T>> item) {
-            return ((IDictionary<string, List<T>>)_tree).Remove(item);
+            return ((IDictionary<string, List<T>>)tree).Remove(item);
         }
 
         public IEnumerator<KeyValuePair<string, List<T>>> GetEnumerator() {
-            return ((IDictionary<string, List<T>>)_tree).GetEnumerator();
+            return ((IDictionary<string, List<T>>)tree).GetEnumerator();
         }
 
         //IEnumerator IEnumerable.GetEnumerator() {
-            //return ((IDictionary<string, List<T>>)_tree).GetEnumerator();
+            //return ((IDictionary<string, List<T>>)tree).GetEnumerator();
         //}
     }
 

--- a/src/compute.geometry/Logging.cs
+++ b/src/compute.geometry/Logging.cs
@@ -9,15 +9,15 @@ namespace compute.geometry
 {
     // Reads a mutable static port at log-event time so the prefix can switch from
     // "CG " to "CG NNNN" mid-run — useful for standalone launches where the port
-    // isn't known until Kestrel binds (default 5000). When _port == 0 the property
+    // isn't known until Kestrel binds (default 5000). When port == 0 the property
     // is not added and the output template's {Port} placeholder renders empty.
     sealed class DynamicPortEnricher : ILogEventEnricher
     {
-        static int _port;
-        public static void SetPort(int port) => _port = port;
+        static int port;
+        public static void SetPort(int port) => DynamicPortEnricher.port = port;
         public void Enrich(LogEvent logEvent, ILogEventPropertyFactory factory)
         {
-            int port = _port;
+            int port = DynamicPortEnricher.port;
             if (port > 0)
                 logEvent.AddPropertyIfAbsent(factory.CreateProperty("Port", port));
         }
@@ -25,7 +25,7 @@ namespace compute.geometry
 
     static class Logging
     {
-        static bool _enabled = false;
+        static bool enabled = false;
         public static List<string> Warnings { get; set; }
         public static List<string> Errors { get; set; }
 
@@ -39,7 +39,7 @@ namespace compute.geometry
         /// populating it.</param>
         public static void Init(int port = 0)
         {
-            if (_enabled)
+            if (enabled)
                 return;
             if (Warnings == null)
                 Warnings = new List<string>();
@@ -77,7 +77,7 @@ namespace compute.geometry
 
             Log.Debug("Logging to {LogPath}", Path.GetDirectoryName(path));
 
-            _enabled = true;
+            enabled = true;
         }
 
         internal static void LogExceptionData(System.Exception ex)

--- a/src/compute.geometry/Program.cs
+++ b/src/compute.geometry/Program.cs
@@ -17,7 +17,7 @@ namespace compute.geometry
     {
         public static IDisposable RhinoCore { get; set; }
         public static DateTime StartTime { get; set; }
-        static string _RhinoSystemDirectory { get; set; }
+        static string rhinoSystemDirectory { get; set; }
 
         static void Main(string[] args)
         {
@@ -50,14 +50,14 @@ namespace compute.geometry
 
             //string rhinoSystemDir = @"C:\dev\github\mcneel\rhino8\src4\bin\Debug";
             //if (System.IO.File.Exists(rhinoSystemDir + "\\Rhino.exe"))
-            //    _RhinoSystemDirectory = rhinoSystemDir;
+            //    rhinoSystemDirectory = rhinoSystemDir;
 
 #endif
 
-            if (String.IsNullOrEmpty(_RhinoSystemDirectory))
+            if (String.IsNullOrEmpty(rhinoSystemDirectory))
                 RhinoInside.Resolver.Initialize();
             else
-                RhinoInside.Resolver.Initialize(_RhinoSystemDirectory);
+                RhinoInside.Resolver.Initialize(rhinoSystemDirectory);
 
 
             StartTime = DateTime.Now;
@@ -164,7 +164,7 @@ namespace compute.geometry
                         }
                         break;
                     case "rhinosysdir":
-                        _RhinoSystemDirectory = value;
+                        rhinoSystemDirectory = value;
                         break;
                     case "load-grasshopper":
                         {

--- a/src/compute.geometry/ResthopperEndpoints.cs
+++ b/src/compute.geometry/ResthopperEndpoints.cs
@@ -59,7 +59,7 @@ namespace compute.geometry
             }
         }
 
-        static object _ghsolvelock = new object();
+        static object ghSolveLock = new object();
 
         static string GrasshopperSolveHelper(Schema input, string body, System.Diagnostics.Stopwatch stopwatch, HttpContext ctx)
         {
@@ -168,7 +168,7 @@ namespace compute.geometry
                 // We can narrow down this lock over time. As it stands, launching many
                 // compute instances on one computer is going to be a better solution anyway
                 // to deal with solving many times simultaniously.
-                lock (_ghsolvelock)
+                lock (ghSolveLock)
                 {
                     json = GrasshopperSolveHelper(input, body, stopwatch, ctx);
                 }

--- a/src/compute.geometry/Shutdown.cs
+++ b/src/compute.geometry/Shutdown.cs
@@ -7,11 +7,11 @@ namespace compute.geometry
 {
     class Shutdown
     {
-        static System.Threading.Timer _timer;
+        static System.Threading.Timer timer;
         internal static Dictionary<int, System.Diagnostics.Process> ParentProcesses { get; set; }
-        static int _parentPort = -1;
-        static int _idleSpan = -1;
-        static DateTime _startTime;
+        static int parentPort = -1;
+        static int idleSpan = -1;
+        static DateTime startTime;
 
         public static void RegisterParentProcess(int processId)
         {
@@ -26,40 +26,40 @@ namespace compute.geometry
 
         public static void RegisterStartTime(DateTime dateTime)
         {
-            _startTime = dateTime;
+            startTime = dateTime;
         }
 
         public static void RegisterParentPort(int port)
         {
-            _parentPort = port;
+            parentPort = port;
         }
 
         public static void RegisterIdleSpan(int spanSeconds)
         {
-            _idleSpan = spanSeconds;
+            idleSpan = spanSeconds;
         }
 
         public static void StartTimer(IHost app)
         {
             bool startTimer = false;
-            if (_timer == null && (ParentProcesses != null))
+            if (timer == null && (ParentProcesses != null))
             {
                 startTimer = true;
             }
-            if (_timer == null && _idleSpan > 0 && _parentPort > 0)
+            if (timer == null && idleSpan > 0 && parentPort > 0)
             {
                 startTimer = true;
             }
 
             if (startTimer)
             {
-                _timer = new System.Threading.Timer(
+                timer = new System.Threading.Timer(
                     new System.Threading.TimerCallback(TimerTask), app, 1000, 5000);
             }
         }
 
-        static System.Net.Http.HttpClient _httpClient;
-        static DateTime _lastSpanCheck = DateTime.Now;
+        static System.Net.Http.HttpClient httpClient;
+        static DateTime lastSpanCheck = DateTime.Now;
 
         private async static void TimerTask(object timerState)
         {
@@ -75,32 +75,32 @@ namespace compute.geometry
                 }
             }
 
-            if (!shutdown && _parentPort > 0 && _idleSpan > 0)
+            if (!shutdown && parentPort > 0 && idleSpan > 0)
             {
                 // Don't check the server every timer tick. Just check when we start approaching
                 // what we think is our span limit.
-                var shouldCheckSpan = DateTime.Now - _lastSpanCheck;
-                //Serilog.Log.Debug($"Idle span value is {_idleSpan}. Elapsed time {shouldCheckSpan.TotalSeconds} seconds. Last span check {_lastSpanCheck.ToLocalTime()}.");
-                if (shouldCheckSpan.TotalSeconds > _idleSpan)
+                var shouldCheckSpan = DateTime.Now - lastSpanCheck;
+                //Serilog.Log.Debug($"Idle span value is {idleSpan}. Elapsed time {shouldCheckSpan.TotalSeconds} seconds. Last span check {lastSpanCheck.ToLocalTime()}.");
+                if (shouldCheckSpan.TotalSeconds > idleSpan)
                 {
-                    if (_httpClient == null)
-                        _httpClient = new System.Net.Http.HttpClient();
-                    string url = $"http://localhost:{_parentPort}/idlespan";
-                    _lastSpanCheck = DateTime.Now;
+                    if (httpClient == null)
+                        httpClient = new System.Net.Http.HttpClient();
+                    string url = $"http://localhost:{parentPort}/idlespan";
+                    lastSpanCheck = DateTime.Now;
                     Serilog.Log.Debug($"The elapsed time has exceeded the idle span limit");
                     Serilog.Log.Debug($"Checking with parent process at {url}.");
                     try
                     {
-                        if (!String.IsNullOrEmpty(Config.ApiKey) && !_httpClient.DefaultRequestHeaders.Contains("RhinoComputeKey"))
-                            _httpClient.DefaultRequestHeaders.Add("RhinoComputeKey", Config.ApiKey);
-                        HttpResponseMessage response = await _httpClient.GetAsync(url);
+                        if (!String.IsNullOrEmpty(Config.ApiKey) && !httpClient.DefaultRequestHeaders.Contains("RhinoComputeKey"))
+                            httpClient.DefaultRequestHeaders.Add("RhinoComputeKey", Config.ApiKey);
+                        HttpResponseMessage response = await httpClient.GetAsync(url);
                         response.EnsureSuccessStatusCode();    
                         string span = response.Content.ReadAsStringAsync().Result;
                         if (!string.IsNullOrEmpty(span))
                         {
                             int serverIdleSpan = int.Parse(span);
                             Serilog.Log.Debug($"Response received. Parent process idle span is {serverIdleSpan} seconds.");
-                            if (serverIdleSpan + (serverIdleSpan * 0.1) > _idleSpan)
+                            if (serverIdleSpan + (serverIdleSpan * 0.1) > idleSpan)
                             {
                                 Serilog.Log.Debug("Idle span limit reached");
                                 shutdown = true;
@@ -121,7 +121,7 @@ namespace compute.geometry
             if (shutdown)
             {
                 Serilog.Log.Debug("Shutting down child process");
-                var elapsedTime = DateTime.Now - _startTime;
+                var elapsedTime = DateTime.Now - startTime;
                 Serilog.Log.Information("Total elapsed time for child process is " + string.Format("{0:D2} days, {1:D2} hrs, {2:D2} mins, {3:D2} secs", elapsedTime.Days, elapsedTime.Hours, elapsedTime.Minutes, elapsedTime.Seconds));
                 var app = timerState as IHost;
                 if (app != null)

--- a/src/rhino.compute/ApiKeyMiddleware.cs
+++ b/src/rhino.compute/ApiKeyMiddleware.cs
@@ -10,18 +10,18 @@ namespace rhino.compute
 {
     public class ApiKeyMiddleware
     {
-        private readonly RequestDelegate _next;
-        private const string APIKEYNAME = "RhinoComputeKey";
+        private readonly RequestDelegate next;
+        private const string API_KEY_NAME = "RhinoComputeKey";
         public ApiKeyMiddleware(RequestDelegate next)
         {
-            _next = next;
+            this.next = next;
         }
         public async Task InvokeAsync(HttpContext context)
         {
-            if (!context.Request.Headers.TryGetValue(APIKEYNAME, out var extractedApiKey))
+            if (!context.Request.Headers.TryGetValue(API_KEY_NAME, out var extractedApiKey))
             {
                 Log.Warning("401 rejecting {Method} {Path}: missing {HeaderName} header",
-                    context.Request.Method, context.Request.Path, APIKEYNAME);
+                    context.Request.Method, context.Request.Path, API_KEY_NAME);
                 context.Response.StatusCode = 401;
                 await context.Response.WriteAsync("Api Key was not provided.");
                 return;
@@ -37,13 +37,13 @@ namespace rhino.compute
             if (!CryptographicOperations.FixedTimeEquals(providedBytes, configuredBytes))
             {
                 Log.Warning("401 rejecting {Method} {Path}: {HeaderName} header does not match server's configured key",
-                    context.Request.Method, context.Request.Path, APIKEYNAME);
+                    context.Request.Method, context.Request.Path, API_KEY_NAME);
                 context.Response.StatusCode = 401;
                 await context.Response.WriteAsync("Unauthorized client.");
                 return;
             }
 
-            await _next(context);
+            await next(context);
         }
     }
 }

--- a/src/rhino.compute/ComputeChildren.cs
+++ b/src/rhino.compute/ComputeChildren.cs
@@ -23,10 +23,10 @@ namespace rhino.compute
         /// </summary>
         public const int MaxChildren = 64;
 
-        static DateTime _lastCall = DateTime.MinValue;
+        static DateTime lastCall = DateTime.MinValue;
         public static void UpdateLastCall()
         {
-            _lastCall = DateTime.Now;
+            lastCall = DateTime.Now;
         }
 
         /// <summary>
@@ -60,9 +60,9 @@ namespace rhino.compute
         /// </returns>
         public static int IdleSpan()
         {
-            if (_lastCall == DateTime.MinValue)
+            if (lastCall == DateTime.MinValue)
                 return -1;
-            var span = DateTime.Now - _lastCall;
+            var span = DateTime.Now - lastCall;
             return (int)span.TotalSeconds;
         }
         /// <summary>
@@ -89,28 +89,28 @@ namespace rhino.compute
             // Simple round robin scheduler using a queue of compute.geometry processes
             int activePort = 0;
 
-            lock (_lockObject)
+            lock (lockObject)
             {
-                if (_computeProcesses.Count > 0)
+                if (computeProcesses.Count > 0)
                 {
-                    Tuple<Process, int> current = _computeProcesses.Dequeue();
+                    Tuple<Process, int> current = computeProcesses.Dequeue();
                     if (!current.Item1.HasExited)
                     {
-                        _computeProcesses.Enqueue(current);
+                        computeProcesses.Enqueue(current);
                         activePort = current.Item2;
                     }
                 }
 
                 if (activePort == 0)
                 {
-                    var aliveProcesses = _computeProcesses.Where(tuple => !tuple.Item1.HasExited).ToList();
-                    _computeProcesses = new Queue<Tuple<Process, int>>(aliveProcesses);
-                    LaunchCompute(_computeProcesses, true);
+                    var aliveProcesses = computeProcesses.Where(tuple => !tuple.Item1.HasExited).ToList();
+                    computeProcesses = new Queue<Tuple<Process, int>>(aliveProcesses);
+                    LaunchCompute(computeProcesses, true);
 
-                    if (_computeProcesses.Count > 0)
+                    if (computeProcesses.Count > 0)
                     {
-                        Tuple<Process, int> current = _computeProcesses.Dequeue();
-                        _computeProcesses.Enqueue(current);
+                        Tuple<Process, int> current = computeProcesses.Dequeue();
+                        computeProcesses.Enqueue(current);
                         activePort = current.Item2;
                     }
                 }
@@ -119,10 +119,10 @@ namespace rhino.compute
             if (0 == activePort)
                 throw new Exception("No compute server found");
 
-            if (_computeProcesses.Count < SpawnCount)
+            if (computeProcesses.Count < SpawnCount)
             {
                 // Bring up other child computes to SpawnCount level
-                for(int i=_computeProcesses.Count; i<SpawnCount; i++)
+                for(int i=computeProcesses.Count; i<SpawnCount; i++)
                 {
                     LaunchCompute(false);
                 }
@@ -134,18 +134,18 @@ namespace rhino.compute
 
         public static void MoveToFrontOfQueue(int port)
         {
-            lock (_lockObject)
+            lock (lockObject)
             {
                 // TODO: We really should be using a simple list with an index
                 // pointing at the next item to use
-                if (_computeProcesses.Count > 1)
+                if (computeProcesses.Count > 1)
                 {
-                    for( int i=0; i<_computeProcesses.Count; i++)
+                    for( int i=0; i<computeProcesses.Count; i++)
                     {
-                        if (_computeProcesses.Peek().Item2 == port)
+                        if (computeProcesses.Peek().Item2 == port)
                             break;
-                        var item = _computeProcesses.Dequeue();
-                        _computeProcesses.Enqueue(item);
+                        var item = computeProcesses.Dequeue();
+                        computeProcesses.Enqueue(item);
                     }
                 }
             }
@@ -153,11 +153,11 @@ namespace rhino.compute
 
         public static void LaunchCompute(bool waitUntilServing)
         {
-            lock (_lockObject)
+            lock (lockObject)
             {
-                if (_computeProcesses.Count >= SpawnCount)
+                if (computeProcesses.Count >= SpawnCount)
                     return;
-                LaunchCompute(_computeProcesses, waitUntilServing);
+                LaunchCompute(computeProcesses, waitUntilServing);
             }
         }
 
@@ -271,7 +271,7 @@ namespace rhino.compute
                 return false;
             }
         }
-        static object _lockObject = new object();
-        static Queue<Tuple<Process, int>> _computeProcesses = new Queue<Tuple<Process, int>>();
+        static object lockObject = new object();
+        static Queue<Tuple<Process, int>> computeProcesses = new Queue<Tuple<Process, int>>();
     }
 }

--- a/src/rhino.compute/Config.cs
+++ b/src/rhino.compute/Config.cs
@@ -66,7 +66,7 @@ namespace rhino.compute
         const string RHINO_COMPUTE_LOG_RETAIN_DAYS = "RHINO_COMPUTE_LOG_RETAIN_DAYS";
         const string RHINO_COMPUTE_DEBUG = "RHINO_COMPUTE_DEBUG";
 
-        readonly static List<string> _warnings = new List<string>();
+        readonly static List<string> warnings = new List<string>();
 
         static T GetEnvironmentVariable<T>(string name, T defaultValue, string deprecatedName = null)
         {
@@ -76,7 +76,7 @@ namespace rhino.compute
             {
                 value = Environment.GetEnvironmentVariable(deprecatedName);
                 if (!string.IsNullOrWhiteSpace(value))
-                    _warnings.Add($"{deprecatedName} is deprecated; use {name} instead");
+                    warnings.Add($"{deprecatedName} is deprecated; use {name} instead");
             }
 
             if (string.IsNullOrWhiteSpace(value))
@@ -94,7 +94,7 @@ namespace rhino.compute
                 if (int.TryParse(value, out int result))
                     return (T)(object)result;
 
-                _warnings.Add($"{name} set to '{value}'; unable to parse as integer");
+                warnings.Add($"{name} set to '{value}'; unable to parse as integer");
                 return defaultValue;
             }
 
@@ -103,7 +103,7 @@ namespace rhino.compute
                 if (long.TryParse(value, out long result))
                     return (T)(object)result;
 
-                _warnings.Add($"{name} set to '{value}'; unable to parse as long");
+                warnings.Add($"{name} set to '{value}'; unable to parse as long");
                 return defaultValue;
             }
 

--- a/src/rhino.compute/Program.cs
+++ b/src/rhino.compute/Program.cs
@@ -87,8 +87,8 @@ namespace rhino.compute
             public bool BlockPrivateUrls { get; set; }
         }
 
-        static System.Diagnostics.Process _parentProcess;
-        static System.Timers.Timer _selfDestructTimer;
+        static System.Diagnostics.Process parentProcess;
+        static System.Timers.Timer selfDestructTimer;
 
         public static void Main(string[] args)
         {
@@ -136,7 +136,7 @@ namespace rhino.compute
                 ComputeChildren.ChildIdleSpan = new System.TimeSpan(0, 0, o.IdleSpanSeconds);
                 int parentProcessId = o.ChildOf;
                 if (parentProcessId > 0)
-                    _parentProcess = System.Diagnostics.Process.GetProcessById(parentProcessId);
+                    parentProcess = System.Diagnostics.Process.GetProcessById(parentProcessId);
                 port = o.Port;
             });
 
@@ -183,9 +183,9 @@ namespace rhino.compute
 
                 }).Build();
 
-            if(_parentProcess?.MainModule != null)
+            if(parentProcess?.MainModule != null)
             {
-                var parentPath = _parentProcess.MainModule.FileName;
+                var parentPath = parentProcess.MainModule.FileName;
                 if (Path.GetFileName(parentPath) == "Rhino.exe")
                 {
                     ComputeChildren.RhinoSysDir = Directory.GetParent(parentPath).FullName;
@@ -220,22 +220,22 @@ namespace rhino.compute
             var logger = host.Services.GetRequiredService<ILogger<ReverseProxyModule>>();
             ReverseProxyModule.InitializeConcurrentRequestLogging(logger);
 
-            if (_parentProcess != null)
+            if (parentProcess != null)
             {
-                _selfDestructTimer = new System.Timers.Timer(1000);
-                _selfDestructTimer.Elapsed += (s, e) =>
+                selfDestructTimer = new System.Timers.Timer(1000);
+                selfDestructTimer.Elapsed += (s, e) =>
                 {
-                    if (_parentProcess.HasExited)
+                    if (parentProcess.HasExited)
                     {
-                        _selfDestructTimer.Stop();
-                        _parentProcess = null;
+                        selfDestructTimer.Stop();
+                        parentProcess = null;
                         Console.WriteLine("self-destruct");
                         Log.Information($"Self-destruct called at {DateTime.Now.ToLocalTime()}");
                         host.StopAsync();
                     }
                 };
-                _selfDestructTimer.AutoReset = true;
-                _selfDestructTimer.Start();
+                selfDestructTimer.AutoReset = true;
+                selfDestructTimer.Start();
             }
             host.Run();
         }
@@ -255,9 +255,9 @@ namespace rhino.compute
 
         public static bool IsParentRhinoProcess(int processId)
         {
-            if (_parentProcess != null && _parentProcess.ProcessName.Contains("rhino", StringComparison.OrdinalIgnoreCase))
+            if (parentProcess != null && parentProcess.ProcessName.Contains("rhino", StringComparison.OrdinalIgnoreCase))
             {
-                return (_parentProcess.Id == processId);
+                return (parentProcess.Id == processId);
             }
             return false;
         }

--- a/src/rhino.compute/ReverseProxy.cs
+++ b/src/rhino.compute/ReverseProxy.cs
@@ -11,22 +11,22 @@ namespace rhino.compute
 {
     public class ReverseProxyModule
     {
-        static bool _initCalled = false;
-        static Task _initTask;
-        static HttpClient _client;
-        private const string _apiKeyHeader = "RhinoComputeKey";
+        static bool initCalled = false;
+        static Task initTask;
+        static HttpClient client;
+        private const string API_KEY_HEADER = "RhinoComputeKey";
 
         static void Initialize()
         {
-            if (_initCalled)
+            if (initCalled)
                 return;
-            _initCalled = true;
+            initCalled = true;
 
             Log.Debug($"Initiliazing reverse proxy at {DateTime.Now.ToLocalTime()}");
 
-            _client = new HttpClient(new HttpClientHandler { AllowAutoRedirect = false });
-            _client.DefaultRequestHeaders.Add("User-Agent", $"compute.rhino3d-proxy/1.0.0");
-            _client.Timeout = TimeSpan.FromSeconds(Config.ReverseProxyRequestTimeout);
+            client = new HttpClient(new HttpClientHandler { AllowAutoRedirect = false });
+            client.DefaultRequestHeaders.Add("User-Agent", $"compute.rhino3d-proxy/1.0.0");
+            client.Timeout = TimeSpan.FromSeconds(Config.ReverseProxyRequestTimeout);
 
             // Launch child processes on start. Getting the base url is enough to get things rolling
             if (ComputeChildren.SpawnOnStartup)
@@ -38,42 +38,42 @@ namespace rhino.compute
         static void InitializeChildren()
         {
             ComputeChildren.UpdateLastCall();
-            _initTask = Task.Run(() =>
+            initTask = Task.Run(() =>
             {
                 var (url, port) = ComputeChildren.GetComputeServerBaseUrl();
                 ComputeChildren.MoveToFrontOfQueue(port);
             });
         }
 
-        static System.Timers.Timer _concurrentRequestLogger;
-        static int _activeConcurrentRequests;
-        static int _maxConcurrentRequests;
+        static System.Timers.Timer concurrentRequestLogger;
+        static int activeConcurrentRequests;
+        static int maxConcurrentRequests;
         class ConcurrentRequestTracker : System.IDisposable
         {
             public ConcurrentRequestTracker()
             {
-                _activeConcurrentRequests++;
-                if (_activeConcurrentRequests > _maxConcurrentRequests)
-                    _maxConcurrentRequests = _activeConcurrentRequests;
+                activeConcurrentRequests++;
+                if (activeConcurrentRequests > maxConcurrentRequests)
+                    maxConcurrentRequests = activeConcurrentRequests;
             }
 
             public void Dispose()
             {
-                _activeConcurrentRequests--;
+                activeConcurrentRequests--;
             }
         }
         public static void InitializeConcurrentRequestLogging(Microsoft.Extensions.Logging.ILogger logger)
         {
             // log once per minute
             var span = new System.TimeSpan(0, 1, 0);
-            _concurrentRequestLogger = new System.Timers.Timer(span.TotalMilliseconds);
-            _concurrentRequestLogger.Elapsed += (s, e) =>
+            concurrentRequestLogger = new System.Timers.Timer(span.TotalMilliseconds);
+            concurrentRequestLogger.Elapsed += (s, e) =>
             {
-                logger.LogInformation($"Max concurrent requests = {_maxConcurrentRequests}");
-                _maxConcurrentRequests = _activeConcurrentRequests;
+                logger.LogInformation($"Max concurrent requests = {maxConcurrentRequests}");
+                maxConcurrentRequests = activeConcurrentRequests;
             };
-            _concurrentRequestLogger.AutoReset = true;
-            _concurrentRequestLogger.Start();
+            concurrentRequestLogger.AutoReset = true;
+            concurrentRequestLogger.Start();
         }
 
         public static void MapEndpoints(IEndpointRouteBuilder app)
@@ -141,11 +141,11 @@ namespace rhino.compute
 
         static async Task AwaitInitTask()
         {
-            var task = _initTask;
+            var task = initTask;
             if (task != null)
             {
                 await task;
-                _initTask = null;
+                initTask = null;
             }
         }
 
@@ -160,8 +160,8 @@ namespace rhino.compute
             {
                 // include RhinoComputeKey header in request to compute child process
                 var req = new HttpRequestMessage(HttpMethod.Post, proxyUrl);
-                if (initialRequest.Headers.TryGetValue(_apiKeyHeader, out var keyHeader))
-                    req.Headers.Add(_apiKeyHeader, keyHeader.ToString());
+                if (initialRequest.Headers.TryGetValue(API_KEY_HEADER, out var keyHeader))
+                    req.Headers.Add(API_KEY_HEADER, keyHeader.ToString());
 
                 using (var stream = initialRequest.BodyReader.AsStream(false))
                 {
@@ -171,7 +171,7 @@ namespace rhino.compute
                         using (var stringContent = new StringContent(body, System.Text.Encoding.UTF8, "applicaton/json"))
                         {
                             req.Content = stringContent;
-                            return await _client.SendAsync(req);
+                            return await client.SendAsync(req);
                         }
                     }
                 }
@@ -179,7 +179,7 @@ namespace rhino.compute
 
             if (method == HttpMethod.Get)
             {
-                return await _client.GetAsync(proxyUrl);
+                return await client.GetAsync(proxyUrl);
             }
 
             throw new System.NotSupportedException("Only GET and POST are currently supported for reverse proxy");


### PR DESCRIPTION
## Summary
  Naming-convention cleanup: removed underscore prefixes from identifiers across the
  rhino.compute and compute.geometry projects to match the house style — private
  fields/locals → `lowerCamelCase`, consts → `SCREAMING_SNAKE_CASE`. Pure refactor;
  no behavior or API changes.

  **rhino.compute** (5 files): `ApiKeyMiddleware`, `Config`, `ComputeChildren`,
  `Program`, `ReverseProxy`. Includes `_apiKeyHeader` → `API_KEY_HEADER` (const).

  **compute.geometry** (11 files): `ApiKeyMiddleware`, `Config`, `DataCache`,
  `GrasshopperDefinition`, `ResthopperEndpoints`, `Shutdown`, `HttpClientHelper`,
  `Program`, `GeometryEndPoint`, `Logging`, `IO/GhPath`.

  ### Collision-safe handling
  - Constructor/setter params that matched a de-underscored field are qualified with
    `this.` (e.g. `ApiKeyMiddleware._next` → `this.next = next;`, GeometryEndPoint's
    `classType`/`constructors`/`methods`, GrasshopperDefinition's `tree`).
  - Static-field/param collisions qualified with the type name (`Logging`'s
    `DynamicPortEnricher.port`, `GeometryResolver.rhinoVersion`).
  - `_default` → `defaultValue` (can't use the `default` keyword).
  - Const `APIKEYNAME` → `API_KEY_NAME` (both ApiKeyMiddleware classes now match).

  ### Out of scope (intentionally untouched)
  - `RhinoCompute.cs` (embedded resource, not compiled) and `RhinoComputeAsync.cs`
    (generated `Rhino.Compute` client SDK).
  - Commented-out dead code (`_GhPathIndexer` in `GhPath.cs`).

  ## Test plan
  - [x] Both projects build clean — 0 errors, and no CS1717 (self-assignment) or
        CS1718 (self-comparison) warnings, confirming no rename silently collided.
  - [x] Functional smoke test: rhino.compute proxy + compute.geometry endpoints
        working as before.