### PR TITLE
Drop underscore prefixes from the Hops project

### DIFF
--- a/src/hops/Config.cs
+++ b/src/hops/Config.cs
@@ -44,7 +44,7 @@ namespace Hops
         const string RHINO_COMPUTE_LOG_RETAIN_DAYS = "RHINO_COMPUTE_LOG_RETAIN_DAYS";
         const string RHINO_COMPUTE_DEBUG = "RHINO_COMPUTE_DEBUG";
 
-        readonly static List<string> _warnings = new List<string>();
+        readonly static List<string> warnings = new List<string>();
 
         static T GetEnvironmentVariable<T>(string name, T defaultValue, string deprecatedName = null)
         {
@@ -54,7 +54,7 @@ namespace Hops
             {
                 value = Environment.GetEnvironmentVariable(deprecatedName);
                 if (!string.IsNullOrWhiteSpace(value))
-                    _warnings.Add($"{deprecatedName} is deprecated; use {name} instead");
+                    warnings.Add($"{deprecatedName} is deprecated; use {name} instead");
             }
 
             if (string.IsNullOrWhiteSpace(value))
@@ -72,7 +72,7 @@ namespace Hops
                 if (int.TryParse(value, out int result))
                     return (T)(object)result;
 
-                _warnings.Add($"{name} set to '{value}'; unable to parse as integer");
+                warnings.Add($"{name} set to '{value}'; unable to parse as integer");
                 return defaultValue;
             }
 
@@ -81,7 +81,7 @@ namespace Hops
                 if (long.TryParse(value, out long result))
                     return (T)(object)result;
 
-                _warnings.Add($"{name} set to '{value}'; unable to parse as long");
+                warnings.Add($"{name} set to '{value}'; unable to parse as long");
                 return defaultValue;
             }
 

--- a/src/hops/FunctionPathInfo.cs
+++ b/src/hops/FunctionPathInfo.cs
@@ -8,10 +8,10 @@ namespace Hops
 {
     public class FunctionPathInfo
     {
-        public FunctionPathInfo(string _fullpath, bool _isfolder)
+        public FunctionPathInfo(string fullPath, bool isFolder)
         {
-            FullPath = _fullpath;
-            IsFolder = _isfolder;
+            FullPath = fullPath;
+            IsFolder = isFolder;
             if (IsFolder)
             {
                 Extension = "";
@@ -111,10 +111,10 @@ namespace Hops
 
     public class UriFunctionPathInfo
     {
-        public UriFunctionPathInfo(string _endpoint, bool _isfolder)
+        public UriFunctionPathInfo(string endpoint, bool isFolder)
         {
-            EndPoint = _endpoint;
-            IsFolder = _isfolder;
+            EndPoint = endpoint;
+            IsFolder = isFolder;
         }
 
         public string EndPoint { get; set; }

--- a/src/hops/HopsAppSettings.cs
+++ b/src/hops/HopsAppSettings.cs
@@ -270,21 +270,21 @@ namespace Hops
             }
         }
 
-        static int _httpTimeout = 0;
+        static int httpTimeout = 0;
         public static int HTTPTimeout
         {
             get
             {
-                if (0 == _httpTimeout)
-                    _httpTimeout = Grasshopper.Instances.Settings.GetValue(HOPS_HTTP_TIMEOUT, 100);
-                return _httpTimeout;
+                if (0 == httpTimeout)
+                    httpTimeout = Grasshopper.Instances.Settings.GetValue(HOPS_HTTP_TIMEOUT, 100);
+                return httpTimeout;
             }
             set
             {
                 if (value >= 1)
                 {
                     Grasshopper.Instances.Settings.SetValue(HOPS_HTTP_TIMEOUT, value);
-                    _httpTimeout = value;
+                    httpTimeout = value;
                 }
             }
 
@@ -309,21 +309,21 @@ namespace Hops
         //    }
         //}
 
-        static int _maxConcurrentRequests = 0;
+        static int maxConcurrentRequests = 0;
         public static int MaxConcurrentRequests
         {
             get
             {
-                if (0 == _maxConcurrentRequests)
-                    _maxConcurrentRequests = Grasshopper.Instances.Settings.GetValue(MAX_CONCURRENT_REQUESTS, 4);
-                return _maxConcurrentRequests;
+                if (0 == maxConcurrentRequests)
+                    maxConcurrentRequests = Grasshopper.Instances.Settings.GetValue(MAX_CONCURRENT_REQUESTS, 4);
+                return maxConcurrentRequests;
             }
             set
             {
                 if (value >= 1)
                 {
                     Grasshopper.Instances.Settings.SetValue(MAX_CONCURRENT_REQUESTS, value);
-                    _maxConcurrentRequests = value;
+                    maxConcurrentRequests = value;
                 }
             }
 

--- a/src/hops/HopsComponent.cs
+++ b/src/hops/HopsComponent.cs
@@ -52,24 +52,24 @@ namespace Hops
     public class HopsComponent : GH_TaskCapableComponent<Schema>, IGH_VariableParameterComponent
     {
         #region Fields
-        int _majorVersion = 0;
-        int _minorVersion = 1;
-        RemoteDefinition _remoteDefinition = null;
-        bool _cacheResultsInMemory = true;
-        bool _cacheResultsOnServer = true;
-        bool _remoteDefinitionRequiresRebuild = false;
-        bool _synchronous = true;
-        bool _showEnabledInput = false;
-        bool _enabledThisSolve = true;
-        bool _showPathInput = false;
-        int _iteration = 0;
+        int majorVersion = 0;
+        int minorVersion = 1;
+        RemoteDefinition remoteDefinition = null;
+        bool cacheResultsInMemory = true;
+        bool cacheResultsOnServer = true;
+        bool remoteDefinitionRequiresRebuild = false;
+        bool synchronous = true;
+        bool showEnabledInput = false;
+        bool enabledThisSolve = true;
+        bool showPathInput = false;
+        int iteration = 0;
 
-        SolveDataList _workingSolveList;
-        int _solveSerialNumber = 0;
-        int _solveRecursionLevel = 0;
-        Schema _lastCreatedSchema = null;
-        static bool _isHeadless = false;
-        static int _currentSolveSerialNumber = 1;
+        SolveDataList workingSolveList;
+        int solveSerialNumber = 0;
+        int solveRecursionLevel = 0;
+        Schema lastCreatedSchema = null;
+        static bool isHeadless = false;
+        static int currentSolveSerialNumber = 1;
         #endregion
 
         static HopsComponent()
@@ -89,7 +89,7 @@ namespace Hops
         public HopsComponent()
           : base("Hops", "Hops", "Solve an external definition using Rhino Compute", "Params", "Util")
         {
-            _isHeadless = Rhino.RhinoApp.IsRunningHeadless;
+            isHeadless = Rhino.RhinoApp.IsRunningHeadless;
         }
 
         public override Guid ComponentGuid => GetType().GUID;
@@ -113,63 +113,63 @@ namespace Hops
         protected override void BeforeSolveInstance()
         {
             Message = "";
-            _enabledThisSolve = true;
-            _lastCreatedSchema = null;
-            _solveRecursionLevel = 0;
+            enabledThisSolve = true;
+            lastCreatedSchema = null;
+            solveRecursionLevel = 0;
 
-            if (_isHeadless &&
+            if (isHeadless &&
                     OnPingDocument() is GH_Document doc)
             {
                 if (doc.ConstantServer.TryGetValue("ComputeRecursionLevel", out GH_Variant recursionLevel))
                     // compute will set the ComputeRecursionLevel 
-                    _solveRecursionLevel = recursionLevel._Int;
+                    solveRecursionLevel = recursionLevel._Int;
                 else
-                    _solveRecursionLevel = HopsAppSettings.RecursionLimit;
+                    solveRecursionLevel = HopsAppSettings.RecursionLimit;
             }
 
-            if (!_solvedCallback)
+            if (!solvedCallback)
             {
-                _solveSerialNumber = _currentSolveSerialNumber++;
-                if (_workingSolveList != null)
-                    _workingSolveList.Canceled = true;
-                _workingSolveList = new SolveDataList(_solveSerialNumber, this, _remoteDefinition, _cacheResultsInMemory);
+                solveSerialNumber = currentSolveSerialNumber++;
+                if (workingSolveList != null)
+                    workingSolveList.Canceled = true;
+                workingSolveList = new SolveDataList(solveSerialNumber, this, remoteDefinition, cacheResultsInMemory);
             }
 
             base.BeforeSolveInstance();
         }
 
-        bool _solvedCallback = false;
+        bool solvedCallback = false;
         public void OnWorkingListComplete()
         {
-            _solvedCallback = true;
-            if (_workingSolveList.SolvedFor(_solveSerialNumber))
+            solvedCallback = true;
+            if (workingSolveList.SolvedFor(solveSerialNumber))
             {
                 ExpireSolution(true);
             }
-            _solvedCallback = false;
+            solvedCallback = false;
         }
 
-        public int SolveSerialNumber => _solveSerialNumber;
+        public int SolveSerialNumber => solveSerialNumber;
 
-        HTTPRecord _httpRecord;
+        HTTPRecord httpRecord;
         public HTTPRecord HTTPRecord
         {
             get
             {
-                if (_httpRecord == null)
-                    _httpRecord = new HTTPRecord();
-                return _httpRecord; 
+                if (httpRecord == null)
+                    httpRecord = new HTTPRecord();
+                return httpRecord; 
             }
         }
 
         protected override void SolveInstance(IGH_DataAccess DA)
         {
-            if (!_enabledThisSolve)
+            if (!enabledThisSolve)
                 return;
-            _iteration++;
+            iteration++;
 
             // Limit recursive calls on compute
-            if (_isHeadless && _solveRecursionLevel > HopsAppSettings.RecursionLimit)
+            if (isHeadless && solveRecursionLevel > HopsAppSettings.RecursionLimit)
             {
                 // Don't allow hops components to run on compute for now. Recursive calls will lock
                 HopsAddRuntimeMessage(
@@ -179,7 +179,7 @@ namespace Hops
 
             }
 
-            if (_showPathInput && DA.Iteration == 0)
+            if (showPathInput && DA.Iteration == 0)
             {
                 string path = "";
                 if (!DA.GetData("_Path", ref path))
@@ -195,34 +195,34 @@ namespace Hops
                 }
             }
 
-            if (string.IsNullOrWhiteSpace(RemoteDefinitionLocation)  && _remoteDefinition?.InternalizedDefinition == null)
+            if (string.IsNullOrWhiteSpace(RemoteDefinitionLocation)  && remoteDefinition?.InternalizedDefinition == null)
             {
                 HopsAddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "No URL or path defined for definition");
                 return;
             }
 
-            if (_showEnabledInput && DA.Iteration == 0)
+            if (showEnabledInput && DA.Iteration == 0)
             {
                 bool enabled = true;
                 if (DA.GetData("_Enabled", ref enabled) && enabled == false)
                 {
-                    _enabledThisSolve = false;
+                    enabledThisSolve = false;
                     return;
                 }
             }
 
             if (InPreSolve)
             {
-                if (_workingSolveList.SolvedFor(_solveSerialNumber))
+                if (workingSolveList.SolvedFor(solveSerialNumber))
                 {
-                    var solvedTask = Task.FromResult(_workingSolveList.SolvedSchema(DA.Iteration));
+                    var solvedTask = Task.FromResult(workingSolveList.SolvedSchema(DA.Iteration));
                     TaskList.Add(solvedTask);
                     return;
                 }
 
                 List<string> warnings;
                 List<string> errors;
-                var inputSchema = _remoteDefinition.CreateSolveInput(DA, _cacheResultsOnServer, _solveRecursionLevel, out warnings, out errors);
+                var inputSchema = remoteDefinition.CreateSolveInput(DA, cacheResultsOnServer, solveRecursionLevel, out warnings, out errors);
                 if (warnings != null && warnings.Count > 0)
                 {
                     foreach (var warning in warnings)
@@ -241,26 +241,26 @@ namespace Hops
                 }
                 if (inputSchema != null)
                 {
-                    if (_lastCreatedSchema==null)
-                        _lastCreatedSchema = inputSchema;
-                    _workingSolveList.Add(inputSchema);
+                    if (lastCreatedSchema==null)
+                        lastCreatedSchema = inputSchema;
+                    workingSolveList.Add(inputSchema);
                 }
                 return;
             }
 
             if (TaskList.Count == 0)
             {
-                _workingSolveList.StartSolving(_synchronous);
-                if (!_synchronous)
+                workingSolveList.StartSolving(synchronous);
+                if (!synchronous)
                 {
                     Message = "solving...";
                     return;
                 }
                 else
                 {
-                    for (int i = 0; i < _workingSolveList.Count; i++)
+                    for (int i = 0; i < workingSolveList.Count; i++)
                     {
-                        var output = _workingSolveList.SolvedSchema(i);
+                        var output = workingSolveList.SolvedSchema(i);
                         TaskList.Add(Task.FromResult(output));
                     }
                 }
@@ -270,7 +270,7 @@ namespace Hops
             {
                 List<string> errors;
                 List<string> warnings;
-                var inputSchema = _remoteDefinition.CreateSolveInput(DA, _cacheResultsOnServer, _solveRecursionLevel, out warnings, out errors);
+                var inputSchema = remoteDefinition.CreateSolveInput(DA, cacheResultsOnServer, solveRecursionLevel, out warnings, out errors);
                 if (warnings != null && warnings.Count > 0)
                 {
                     foreach (var warning in warnings)
@@ -289,9 +289,9 @@ namespace Hops
                 }
                 if (inputSchema != null)
                 {
-                    schema = _remoteDefinition.Solve(inputSchema, _cacheResultsInMemory);
-                    if (_lastCreatedSchema == null)
-                        _lastCreatedSchema = inputSchema;
+                    schema = remoteDefinition.Solve(inputSchema, cacheResultsInMemory);
+                    if (lastCreatedSchema == null)
+                        lastCreatedSchema = inputSchema;
                 }
                 else
                     schema = null;
@@ -307,7 +307,7 @@ namespace Hops
 
             if (schema != null)
             {
-                _remoteDefinition.SetComponentOutputs(schema, DA, Params.Output, this);
+                remoteDefinition.SetComponentOutputs(schema, DA, Params.Output, this);
             }
         }
 
@@ -326,16 +326,16 @@ namespace Hops
             bool rc = base.Write(writer);
             if (rc)
             {
-                writer.SetVersion(TagVersion, _majorVersion, _minorVersion, 0);
+                writer.SetVersion(TagVersion, majorVersion, minorVersion, 0);
                 writer.SetString(TagPath, RemoteDefinitionLocation);
-                writer.SetBoolean(TagCacheResultsOnServer, _cacheResultsOnServer);
-                writer.SetBoolean(TagCacheResultsInMemory, _cacheResultsInMemory);
-                writer.SetBoolean(TagSynchronousSolve, _synchronous);
-                writer.SetBoolean(TagShowEnabled, _showEnabledInput);
-                writer.SetBoolean(TagShowPath, _showPathInput);
-                if(_remoteDefinition?.InternalizedDefinition != null)
+                writer.SetBoolean(TagCacheResultsOnServer, cacheResultsOnServer);
+                writer.SetBoolean(TagCacheResultsInMemory, cacheResultsInMemory);
+                writer.SetBoolean(TagSynchronousSolve, synchronous);
+                writer.SetBoolean(TagShowEnabled, showEnabledInput);
+                writer.SetBoolean(TagShowPath, showPathInput);
+                if(remoteDefinition?.InternalizedDefinition != null)
                 {
-                    writer.SetByteArray(TagInternalizeDefinition, _remoteDefinition.InternalizedDefinition);
+                    writer.SetByteArray(TagInternalizeDefinition, remoteDefinition.InternalizedDefinition);
                 }
             }
             return rc;
@@ -346,40 +346,40 @@ namespace Hops
             if (rc)
             {
                 var version = reader.GetVersion(TagVersion);
-                _majorVersion = version.major;
-                _minorVersion = version.minor;
+                majorVersion = version.major;
+                minorVersion = version.minor;
                 string path = reader.GetString(TagPath);
 
-                bool cacheResults = _cacheResultsOnServer;
+                bool cacheResults = cacheResultsOnServer;
                 if (reader.TryGetBoolean(TagCacheResultsOnServer, ref cacheResults))
-                    _cacheResultsOnServer = cacheResults;
+                    cacheResultsOnServer = cacheResults;
 
-                cacheResults = _cacheResultsInMemory;
+                cacheResults = cacheResultsInMemory;
                 if (reader.TryGetBoolean(TagCacheResultsInMemory, ref cacheResults))
-                    _cacheResultsInMemory = cacheResults;
+                    cacheResultsInMemory = cacheResults;
 
-                bool synchronous = _synchronous;
+                bool synchronous = this.synchronous;
                 if (reader.TryGetBoolean(TagSynchronousSolve, ref synchronous))
-                    _synchronous = synchronous;
+                    this.synchronous = synchronous;
 
-                bool showEnabled = _showEnabledInput;
+                bool showEnabled = showEnabledInput;
                 if (reader.TryGetBoolean(TagShowEnabled, ref showEnabled))
-                    _showEnabledInput = showEnabled;
+                    showEnabledInput = showEnabled;
 
-                bool showPath = _showPathInput;
+                bool showPath = showPathInput;
                 if (reader.TryGetBoolean(TagShowPath, ref showPath))
-                    _showPathInput = showPath;
+                    showPathInput = showPath;
 
                 if(reader.ItemExists(TagInternalizeDefinition))
                 {
                     try
                     {
                         byte[] internalizedDefinition = reader.GetByteArray(TagInternalizeDefinition);
-                        if(_remoteDefinition == null)
-                            _remoteDefinition = RemoteDefinition.Create(null, this);
-                        _remoteDefinition.InternalizedDefinition = internalizedDefinition;
-                        _remoteDefinition._pathType = RemoteDefinition.PathType.InternalizedDefinition;
-                        _remoteDefinition.GetRemoteDescription();
+                        if(remoteDefinition == null)
+                            remoteDefinition = RemoteDefinition.Create(null, this);
+                        remoteDefinition.InternalizedDefinition = internalizedDefinition;
+                        remoteDefinition.pathType = RemoteDefinition.PathType.InternalizedDefinition;
+                        remoteDefinition.GetRemoteDescription();
                     }
                     catch(Exception ex)
                     {
@@ -452,25 +452,25 @@ namespace Hops
             }
         }
 
-        static System.Drawing.Bitmap _hops24Icon;
-        static System.Drawing.Bitmap _hops48Icon;
+        static System.Drawing.Bitmap hops24Icon;
+        static System.Drawing.Bitmap hops48Icon;
         static System.Drawing.Bitmap Hops24Icon()
         {
-            if (_hops24Icon == null)
+            if (hops24Icon == null)
             {
                 var stream = typeof(HopsComponent).Assembly.GetManifestResourceStream("Hops.resources.Hops_24x24.png");
-                _hops24Icon = new System.Drawing.Bitmap(stream);
+                hops24Icon = new System.Drawing.Bitmap(stream);
             }
-            return _hops24Icon;
+            return hops24Icon;
         }
         public static System.Drawing.Bitmap Hops48Icon()
         {
-            if (_hops48Icon == null)
+            if (hops48Icon == null)
             {
                 var stream = typeof(HopsComponent).Assembly.GetManifestResourceStream("Hops.resources.Hops_48x48.png");
-                _hops48Icon = new System.Drawing.Bitmap(stream);
+                hops48Icon = new System.Drawing.Bitmap(stream);
             }
-            return _hops48Icon;
+            return hops48Icon;
         }
 
         public override void AppendAdditionalMenuItems(ToolStripDropDown menu)
@@ -501,9 +501,9 @@ namespace Hops
             menu.Items.Add(new ToolStripSeparator());
 
             var tsi = new ToolStripMenuItem("&Path...", null, (sender, e) => { ShowSetDefinitionUi(); });
-            if (!_showPathInput)
+            if (!showPathInput)
                 tsi.Font = new System.Drawing.Font(tsi.Font, System.Drawing.FontStyle.Bold);
-            tsi.Enabled = !_showPathInput;
+            tsi.Enabled = !showPathInput;
             menu.Items.Add(tsi);
 
             tsi = AddFunctionMgrControl();
@@ -513,7 +513,7 @@ namespace Hops
             tsi = new ToolStripMenuItem("Internalize Definition", null, (s, e) => {
                 if (File.Exists(RemoteDefinitionLocation))
                 {
-                    _remoteDefinition.InternalizeDefinition(RemoteDefinitionLocation);
+                    remoteDefinition.InternalizeDefinition(RemoteDefinitionLocation);
                     DefineInputsAndOutputs();                 
                 }
             });
@@ -527,44 +527,44 @@ namespace Hops
             menu.Items.Add(new ToolStripSeparator());
 
             tsi = new ToolStripMenuItem("Show Input: Path", null, (s, e) => {
-                _showPathInput = !_showPathInput;
+                showPathInput = !showPathInput;
                 DefineInputsAndOutputs();
             });
             tsi.ToolTipText = "Create input for path";
-            tsi.Checked = _showPathInput;
+            tsi.Checked = showPathInput;
             menu.Items.Add(tsi);
 
             tsi = new ToolStripMenuItem("Show Input: Enabled", null, (s, e) => {
-                _showEnabledInput = !_showEnabledInput;
+                showEnabledInput = !showEnabledInput;
                 DefineInputsAndOutputs();
             });
             tsi.ToolTipText = "Create input for enabled";
-            tsi.Checked = _showEnabledInput;
+            tsi.Checked = showEnabledInput;
             menu.Items.Add(tsi);
 
-            tsi = new ToolStripMenuItem("Asynchronous", null, (s, e) => { _synchronous = !_synchronous; });
+            tsi = new ToolStripMenuItem("Asynchronous", null, (s, e) => { synchronous = !synchronous; });
             tsi.ToolTipText = "Do not block while solving";
-            tsi.Checked = !_synchronous;
+            tsi.Checked = !synchronous;
             menu.Items.Add(tsi);
 
-            tsi = new ToolStripMenuItem("Cache In Memory", null, (s, e) => { _cacheResultsInMemory = !_cacheResultsInMemory; });
+            tsi = new ToolStripMenuItem("Cache In Memory", null, (s, e) => { cacheResultsInMemory = !cacheResultsInMemory; });
             tsi.ToolTipText = "Keep previous results in memory cache";
-            tsi.Checked = _cacheResultsInMemory;
+            tsi.Checked = cacheResultsInMemory;
             menu.Items.Add(tsi);
 
-            tsi = new ToolStripMenuItem("Cache On Server", null, (s, e) => { _cacheResultsOnServer = !_cacheResultsOnServer; });
+            tsi = new ToolStripMenuItem("Cache On Server", null, (s, e) => { cacheResultsOnServer = !cacheResultsOnServer; });
             tsi.ToolTipText = "Tell the compute server to cache results for reuse in the future";
-            tsi.Checked = _cacheResultsOnServer;
+            tsi.Checked = cacheResultsOnServer;
             menu.Items.Add(tsi);
 
             var exportTsi = new ToolStripMenuItem("Export");
-            exportTsi.Enabled = _remoteDefinition != null;
+            exportTsi.Enabled = remoteDefinition != null;
             menu.Items.Add(exportTsi);
             tsi = new ToolStripMenuItem("Export python sample...", null, (s, e) => { ExportAsPython(); });
             exportTsi.DropDownItems.Add(tsi);
 
             var restAPITsi = new ToolStripMenuItem("REST API");
-            restAPITsi.Enabled = _remoteDefinition != null;
+            restAPITsi.Enabled = remoteDefinition != null;
             exportTsi.DropDownItems.Add(restAPITsi);
 
             tsi = new ToolStripMenuItem("Last IO request...", null, (s, e) => { ExportLastIORequest(); });
@@ -703,10 +703,10 @@ namespace Hops
         /// </summary>
         class ComponentAttributes : GH_ComponentAttributes
         {
-            HopsComponent _component;
+            HopsComponent component;
             public ComponentAttributes(HopsComponent parentComponent) : base(parentComponent)
             {
-                _component = parentComponent;
+                component = parentComponent;
             }
 
             protected override void Render(GH_Canvas canvas, System.Drawing.Graphics graphics, GH_CanvasChannel channel)
@@ -714,7 +714,7 @@ namespace Hops
                 base.Render(canvas, graphics, channel);
                 if (channel == GH_CanvasChannel.Objects &&
                     GH_Canvas.ZoomFadeMedium > 0 &&
-                    !string.IsNullOrWhiteSpace(_component.RemoteDefinitionLocation)
+                    !string.IsNullOrWhiteSpace(component.RemoteDefinitionLocation)
                     )
                 {
                     RenderHop(graphics, GH_Canvas.ZoomFadeMedium, new System.Drawing.PointF(Bounds.Right, Bounds.Bottom));
@@ -732,11 +732,11 @@ namespace Hops
             {
                 try
                 {
-                    _component.ShowSetDefinitionUi();
+                    component.ShowSetDefinitionUi();
                 }
                 catch(Exception ex)
                 {
-                    _component.HopsAddRuntimeMessage(GH_RuntimeMessageLevel.Error, ex.Message);
+                    component.HopsAddRuntimeMessage(GH_RuntimeMessageLevel.Error, ex.Message);
                 }
                 return base.RespondToMouseDoubleClick(sender, e);
             }
@@ -762,7 +762,7 @@ namespace Hops
 
         void ExportAsPython()
         {
-            if (_lastCreatedSchema == null)
+            if (lastCreatedSchema == null)
             {
                 Eto.Forms.MessageBox.Show("No input created. Run this component at least once", Eto.Forms.MessageBoxType.Error);
                 return;
@@ -790,7 +790,7 @@ sb.Append(@"'
 input_trees = []
 ");
 
-                foreach(var val in _lastCreatedSchema.Values)
+                foreach(var val in lastCreatedSchema.Values)
                 {
                     sb.AppendLine($"tree = gh.DataTree(\"{val.ParamName}\")");
                     foreach (var kv in val.InnerTree)
@@ -897,12 +897,12 @@ for value in values:
             }
         }
 
-        string _tempPath;
+        string tempPath;
         void RebuildWithNewPathAndRecompute(string path)
         {
             if (string.Equals(path, RemoteDefinitionLocation))
                 return;
-            _tempPath = path;
+            tempPath = path;
             Rhino.RhinoApp.Idle += RebuildAfterSolution;
         }
 
@@ -912,8 +912,8 @@ for value in values:
             if (doc != null && doc.SolutionDepth == 0)
             {
                 Rhino.RhinoApp.Idle -= RebuildAfterSolution;
-                RemoteDefinitionLocation = _tempPath;
-                _tempPath = null;
+                RemoteDefinitionLocation = tempPath;
+                tempPath = null;
             }
         }
 
@@ -922,9 +922,9 @@ for value in values:
         {
             get
             {
-                if (_remoteDefinition != null)
+                if (remoteDefinition != null)
                 {
-                    return _remoteDefinition.Path;
+                    return remoteDefinition.Path;
                 }
                 return string.Empty;
             }
@@ -934,14 +934,14 @@ for value in values:
                 // This way you can poke the path button to force a refresh in case the situation
                 // on the server has changed.
                 {
-                    if(_remoteDefinition != null)
+                    if(remoteDefinition != null)
                     {
-                        _remoteDefinition.Dispose();
-                        _remoteDefinition = null;
+                        remoteDefinition.Dispose();
+                        remoteDefinition = null;
                     }
                     if (!string.IsNullOrWhiteSpace(value))
                     {
-                        _remoteDefinition = RemoteDefinition.Create(value, this);
+                        remoteDefinition = RemoteDefinition.Create(value, this);
                         HopsLog.Log.Debug($"Remote definition location set to {value}");
                         DefineInputsAndOutputs();
                     }
@@ -952,7 +952,7 @@ for value in values:
         public override void CollectData()
         {
             base.CollectData();
-            if (_showPathInput &&
+            if (showPathInput &&
                 !string.IsNullOrWhiteSpace(RemoteDefinitionLocation) &&
                 !Params.Input[0].VolatileData.IsEmpty)
             {
@@ -1061,19 +1061,19 @@ for value in values:
 
         void DefineInputsAndOutputs()
         {
-            if (_remoteDefinition != null)
+            if (remoteDefinition != null)
             {
                 ClearRuntimeMessages();
-                string description = _remoteDefinition.GetDescription(out System.Drawing.Bitmap customIcon);
+                string description = remoteDefinition.GetDescription(out System.Drawing.Bitmap customIcon);
 
-                if (_remoteDefinition.IsNotResponingUrl())
+                if (remoteDefinition.IsNotResponingUrl())
                 {
                     HopsAddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Unable to connect to server");
                     Grasshopper.Instances.ActiveCanvas?.Invalidate();
                     return;
                 }
 
-                if (_remoteDefinition.IsInvalidUrl())
+                if (remoteDefinition.IsInvalidUrl())
                 {
                     HopsAddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Path appears valid, but to something that is not Hops related");
                     Grasshopper.Instances.ActiveCanvas?.Invalidate();
@@ -1100,8 +1100,8 @@ for value in values:
                 {
                     Description = description;
                 }
-                var inputs = _remoteDefinition.GetInputParams();
-                var outputs = _remoteDefinition.GetOutputParams();
+                var inputs = remoteDefinition.GetInputParams();
+                var outputs = remoteDefinition.GetOutputParams();
 
                 bool buildInputs = inputs != null;
                 bool buildOutputs = outputs != null;
@@ -1120,12 +1120,12 @@ for value in values:
                 }
 
                 int inputCount = inputs!=null ? inputs.Count : 0;
-                if (_showEnabledInput)
+                if (showEnabledInput)
                     inputCount++;
-                if (_showPathInput)
+                if (showPathInput)
                     inputCount++;
      
-                if(_iteration == 0)
+                if(iteration == 0)
                 {
                     if (buildInputs && Params.Input.Count == inputCount)
                     {
@@ -1181,7 +1181,7 @@ for value in values:
 
                     var mgr = CreateInputManager();
 
-                    if (_showPathInput)
+                    if (showPathInput)
                     {
                         const string name = "_Path";
                         int paramIndex = mgr.AddTextParameter(name, "Path", "URL to remote process", GH_ParamAccess.item);
@@ -1192,7 +1192,7 @@ for value in values:
                         }
                     }
 
-                    if (_showEnabledInput)
+                    if (showEnabledInput)
                     {
                         const string name = "_Enabled";
                         int paramIndex = mgr.AddBooleanParameter(name, "Enabled", "Enabled state for solving", GH_ParamAccess.item);
@@ -1583,9 +1583,9 @@ for value in values:
                 }
 
                 var mgr = CreateInputManager();
-                if (_showPathInput)
+                if (showPathInput)
                     mgr.AddTextParameter("_Path", "Path", "URL to remote process", GH_ParamAccess.item);
-                if (_showEnabledInput)
+                if (showEnabledInput)
                     mgr.AddBooleanParameter("_Enabled", "Enabled", "Enabled state for solving", GH_ParamAccess.item, true);
                 Params.OnParametersChanged();
                 Grasshopper.Instances.ActiveCanvas?.Invalidate();
@@ -1607,17 +1607,17 @@ for value in values:
 
         public void OnRemoteDefinitionChanged()
         {
-            if (_remoteDefinitionRequiresRebuild)
+            if (remoteDefinitionRequiresRebuild)
                 return;
 
             // this is typically called on a different thread than the main UI thread
-            _remoteDefinitionRequiresRebuild = true;
+            remoteDefinitionRequiresRebuild = true;
             Rhino.RhinoApp.Idle += RhinoApp_Idle;
         }
 
         private void RhinoApp_Idle(object sender, EventArgs e)
         {
-            if (!_remoteDefinitionRequiresRebuild)
+            if (!remoteDefinitionRequiresRebuild)
             {
                 // not sure how this could happen, but in case it does just
                 // remove the idle event and bail
@@ -1634,7 +1634,7 @@ for value in values:
 
             // stop the idle event watcher
             Rhino.RhinoApp.Idle -= RhinoApp_Idle;
-            _remoteDefinitionRequiresRebuild = false;
+            remoteDefinitionRequiresRebuild = false;
             DefineInputsAndOutputs();
         }
     }

--- a/src/hops/HopsFunctionMgr.cs
+++ b/src/hops/HopsFunctionMgr.cs
@@ -103,67 +103,67 @@ namespace Hops
             }
         }
 
-        static Image _funcMgr24Icon;
-        static Image _funcMgr48Icon;
-        static Image _deleteIcon;
-        static Image _addIcon;
-        static Image _editIcon;
+        static Image funcMgr24Icon;
+        static Image funcMgr48Icon;
+        static Image deleteIcon;
+        static Image addIcon;
+        static Image editIcon;
 
         public static Image FuncMgr24Icon()
         {
-            if (_funcMgr24Icon == null)
+            if (funcMgr24Icon == null)
             {
                 var stream = typeof(HopsComponent).Assembly.GetManifestResourceStream("Hops.resources.Hops_Function_Mgr_24x24.png");
-                _funcMgr24Icon = Image.FromStream(stream);
+                funcMgr24Icon = Image.FromStream(stream);
             }
-            return _funcMgr24Icon;
+            return funcMgr24Icon;
         }
         public static Image FuncMgr48Icon()
         {
-            if (_funcMgr48Icon == null)
+            if (funcMgr48Icon == null)
             {
                 var stream = typeof(HopsComponent).Assembly.GetManifestResourceStream("Hops.resources.Hops_Function_Mgr_48x48.png");
-                _funcMgr48Icon = Image.FromStream(stream);
+                funcMgr48Icon = Image.FromStream(stream);
             }
-            return _funcMgr48Icon;
+            return funcMgr48Icon;
         }
         public static Image DeleteIcon()
         {
-            if (_deleteIcon == null)
+            if (deleteIcon == null)
             {
                 var stream = typeof(HopsComponent).Assembly.GetManifestResourceStream("Hops.resources.Close_Toolbar_Active_20x20.png");
-                _deleteIcon = Image.FromStream(stream);
+                deleteIcon = Image.FromStream(stream);
             }
-            return _deleteIcon;
+            return deleteIcon;
         }
         public static Image AddIcon()
         {
-            if (_addIcon == null)
+            if (addIcon == null)
             {
                 var stream = typeof(HopsComponent).Assembly.GetManifestResourceStream("Hops.resources.Open_Toolbar_Active_20x20.png");
-                _addIcon = Image.FromStream(stream);
+                addIcon = Image.FromStream(stream);
             }
-            return _addIcon;
+            return addIcon;
         }
         public static Image EditIcon()
         {
-            if (_editIcon == null)
+            if (editIcon == null)
             {
                 var stream = typeof(HopsComponent).Assembly.GetManifestResourceStream("Hops.resources.edit_16x16.png");
-                _editIcon = Image.FromStream(stream);
+                editIcon = Image.FromStream(stream);
             }
-            return _editIcon;
+            return editIcon;
         }
-        static System.Net.Http.HttpClient _httpClient = null;
+        static System.Net.Http.HttpClient httpClient = null;
         public static System.Net.Http.HttpClient HttpClient
         {
             get
             {
-                if (_httpClient == null)
+                if (httpClient == null)
                 {
-                    _httpClient = new System.Net.Http.HttpClient();
+                    httpClient = new System.Net.Http.HttpClient();
                 }
-                return _httpClient;
+                return httpClient;
             }
         }
     }

--- a/src/hops/MemoryCache.cs
+++ b/src/hops/MemoryCache.cs
@@ -9,24 +9,24 @@ namespace Hops
     /// </summary>
     static class MemoryCache
     {
-        static System.Runtime.Caching.MemoryCache _memCache = new System.Runtime.Caching.MemoryCache("HopsCache");
+        static System.Runtime.Caching.MemoryCache memoryCache = new System.Runtime.Caching.MemoryCache("HopsCache");
 
         public static Schema Get(string key)
         {
-            var cachedResults = _memCache.Get(key) as Schema;
+            var cachedResults = memoryCache.Get(key) as Schema;
             return cachedResults;
         }
 
         public static void Set(string key, Schema schema)
         {
             EntryCount++;
-            _memCache.Set(key, schema, new System.Runtime.Caching.CacheItemPolicy());
+            memoryCache.Set(key, schema, new System.Runtime.Caching.CacheItemPolicy());
         }
 
         public static void ClearCache()
         {
-            _memCache.Dispose();
-            _memCache = new System.Runtime.Caching.MemoryCache("HopsCache");
+            memoryCache.Dispose();
+            memoryCache = new System.Runtime.Caching.MemoryCache("HopsCache");
             EntryCount = 0;
         }
 

--- a/src/hops/RemoteDefinition.cs
+++ b/src/hops/RemoteDefinition.cs
@@ -33,17 +33,17 @@ namespace Hops
             InvalidUrl //responding, but does not appear to have anything to do with solving
         }
 
-        HopsComponent _parentComponent;
-        Dictionary<string, Tuple<InputParamSchema, IGH_Param>> _inputParams;
-        Dictionary<string, IGH_Param> _outputParams;
-        string _description = null;
-        System.Drawing.Bitmap _customIcon = null;
-        string _path = null;
-        string _cacheKey = null;
-        public byte[] _internalizedDefinition = null;
-        const string _apiKeyName = "RhinoComputeKey";
-        public PathType? _pathType;
-        public string _filename = string.Empty;
+        HopsComponent parentComponent;
+        Dictionary<string, Tuple<InputParamSchema, IGH_Param>> inputParams;
+        Dictionary<string, IGH_Param> outputParams;
+        string description = null;
+        System.Drawing.Bitmap customIcon = null;
+        string path = null;
+        string cacheKey = null;
+        public byte[] internalizedDefinition = null;
+        const string API_KEY_NAME = "RhinoComputeKey";
+        public PathType? pathType;
+        public string filename = string.Empty;
 
         public static bool IsWebUrl(string path)
         {
@@ -82,29 +82,29 @@ namespace Hops
             }
             if (IsGrasshopperDefinition(filename))
             {
-                rc._filename = filename;
+                rc.filename = filename;
             }
             return rc;
         }
 
         public void InternalizeDefinition(string path)
         {
-            _internalizedDefinition = System.IO.File.ReadAllBytes(path);
-            _pathType = PathType.InternalizedDefinition;
+            internalizedDefinition = System.IO.File.ReadAllBytes(path);
+            pathType = PathType.InternalizedDefinition;
             RemoteDefinitionCache.Remove(this);
-            _path = null;
+            this.path = null;
         }
 
         private RemoteDefinition(string path, HopsComponent parentComponent)
         {
-            _parentComponent = parentComponent;
-            _path = path;
-            _internalizedDefinition = null;
+            this.parentComponent = parentComponent;
+            this.path = path;
+            internalizedDefinition = null;
         }
 
         public void Dispose()
         {
-            _parentComponent = null;
+            parentComponent = null;
             RemoteDefinitionCache.Remove(this);
         }
 
@@ -122,16 +122,16 @@ namespace Hops
 
         public void ResetPathType()
         {
-            _pathType = null;
+            pathType = null;
         }
 
         PathType GetPathType()
         {
-            if (!_pathType.HasValue)
+            if (!pathType.HasValue)
             {
-                _pathType = GetPathType(_path);
+                pathType = GetPathType(path);
             }
-            return _pathType.Value;
+            return pathType.Value;
         }
 
         public static PathType GetPathType(string path)
@@ -160,43 +160,43 @@ namespace Hops
             return rc;
         }
 
-        public string Path { get { return _path; } set { _path = value; } }
-        public byte[] InternalizedDefinition { get { return _internalizedDefinition; } set { _internalizedDefinition = value; } }
+        public string Path { get { return path; } set { path = value; } }
+        public byte[] InternalizedDefinition { get { return internalizedDefinition; } set { internalizedDefinition = value; } }
 
         public void OnWatchedFileChanged()
         {
-            _cacheKey = null;
-            _description = null;
-            if (_parentComponent != null)
-                _parentComponent.OnRemoteDefinitionChanged();
+            cacheKey = null;
+            description = null;
+            if (parentComponent != null)
+                parentComponent.OnRemoteDefinitionChanged();
         }
 
         public Dictionary<string, Tuple<InputParamSchema, IGH_Param>> GetInputParams()
         {
-            if( _inputParams == null)
+            if( inputParams == null)
             {
                 GetRemoteDescription();
             }
-            return _inputParams;
+            return inputParams;
         }
 
         public Dictionary<string, IGH_Param> GetOutputParams()
         {
-            if (_outputParams == null)
+            if (outputParams == null)
             {
                 GetRemoteDescription();
             }
-            return _outputParams;
+            return outputParams;
         }
 
         public string GetDescription(out System.Drawing.Bitmap customIcon)
         {
-            if (_description == null)
+            if (description == null)
             {
                 GetRemoteDescription();
             }
-            customIcon = _customIcon;
-            return _description;
+            customIcon = this.customIcon;
+            return description;
         }
 
         public void GetRemoteDescription()
@@ -265,30 +265,30 @@ namespace Hops
                 }
                 else
                 {
-                    if(_internalizedDefinition != null)
-                        schema.Algo = Convert.ToBase64String(_internalizedDefinition);
+                    if(internalizedDefinition != null)
+                        schema.Algo = Convert.ToBase64String(internalizedDefinition);
                 }
                 schema.AbsoluteTolerance = GetDocumentTolerance();
                 schema.AngleTolerance = GetDocumentAngleTolerance();
                 schema.ModelUnits = GetDocumentUnits();
-                schema.FileName = _filename;
+                schema.FileName = filename;
                 string inputJson = JsonConvert.SerializeObject(schema);
                 string requestContent = "{";
                 requestContent += "\"URL\": \"" + postUrl + "\"," + Environment.NewLine;
                 requestContent += "\"Method\": \"POST" + "\"," + Environment.NewLine;
                 requestContent += "\"Content\": " + inputJson  + Environment.NewLine;
                 requestContent += "}";
-                _parentComponent.HTTPRecord.IORequest = requestContent;
+                parentComponent.HTTPRecord.IORequest = requestContent;
                 var content = new System.Net.Http.StringContent(inputJson, Encoding.UTF8, "application/json");
                 var request = new System.Net.Http.HttpRequestMessage(System.Net.Http.HttpMethod.Post, postUrl) { Content = content };
                 AddApiKeyHeader(request);
                 var cts = CreateTimeoutCts();
                 var fileNameMsg = String.Empty;
-                if (!String.IsNullOrEmpty(_filename))
-                    fileNameMsg = $" with {_filename}";
+                if (!String.IsNullOrEmpty(filename))
+                    fileNameMsg = $" with {filename}";
                 HopsLog.Log.Debug($"Sending POST request to {postUrl}{fileNameMsg}");
                 responseTask = HttpClient.SendAsync(request, cts.Token);
-                _parentComponent.HTTPRecord.Schema = schema;
+                parentComponent.HTTPRecord.Schema = schema;
                 contentToDispose = content;
                 requestToDispose = request;
                 ctsToDispose = cts;
@@ -299,7 +299,7 @@ namespace Hops
                 requestContent += "\"URL\": \"" + address + "\"," + Environment.NewLine;
                 requestContent += "\"Method\": \"GET" + "\"" + Environment.NewLine;
                 requestContent += "}";
-                _parentComponent.HTTPRecord.IORequest = requestContent;
+                parentComponent.HTTPRecord.IORequest = requestContent;
                 var cts = CreateTimeoutCts();
                 responseTask = HttpClient.GetAsync(address, cts.Token);
                 ctsToDispose = cts;
@@ -311,7 +311,7 @@ namespace Hops
                 HopsLog.Log.Debug($"Received response {responseMessage.StatusCode} in {sw.ElapsedMilliseconds}ms");
                 var remoteSolvedData = responseMessage.Content;
                 var stringResult = remoteSolvedData.ReadAsStringAsync().Result;
-                _parentComponent.HTTPRecord.IOResponse = stringResult;
+                parentComponent.HTTPRecord.IOResponse = stringResult;
 
                 // Detect 401 BEFORE attempting to parse the body as JSON. The middleware's
                 // response body is plain text ("Api Key was not provided." / "Unauthorized
@@ -326,19 +326,19 @@ namespace Hops
                     HopsLog.Log.Error(serverMessage);
                     var errSchema = new IoResponseSchema();
                     errSchema.Errors.Add(serverMessage);
-                    _parentComponent.HTTPRecord.IOResponseSchema = errSchema;
+                    parentComponent.HTTPRecord.IOResponseSchema = errSchema;
                 }
                 else if (string.IsNullOrEmpty(stringResult))
                 {
-                    _pathType = PathType.InvalidUrl; // Looks like a valid but not related URL
-                    _parentComponent.HTTPRecord.IOResponse = "Invalid URL";
+                    this.pathType = PathType.InvalidUrl; // Looks like a valid but not related URL
+                    parentComponent.HTTPRecord.IOResponse = "Invalid URL";
                 }
                 else
                 {
                     responseSchema = JsonConvert.DeserializeObject<IoResponseSchema>(stringResult);
-                    _cacheKey = responseSchema.CacheKey;
-                    _filename = responseSchema.FileName;
-                    _parentComponent.HTTPRecord.IOResponseSchema = responseSchema;
+                    cacheKey = responseSchema.CacheKey;
+                    filename = responseSchema.FileName;
+                    parentComponent.HTTPRecord.IOResponseSchema = responseSchema;
                 }
             }
 
@@ -348,8 +348,8 @@ namespace Hops
 
             if (responseSchema != null)
             { 
-                _description = responseSchema.Description;
-                _customIcon = null;
+                description = responseSchema.Description;
+                this.customIcon = null;
                 if (!string.IsNullOrWhiteSpace(responseSchema.Icon))
                 {
                     try
@@ -366,21 +366,21 @@ namespace Hops
                             var method = typeof(Rhino.UI.DrawingUtilities).GetMethod("BitmapFromSvg", new[] {typeof(string), typeof(int), typeof(int)} );
                             if (method != null)
                             {
-                                _customIcon = method.Invoke(null, new object[] { svg, 24, 24 }) as System.Drawing.Bitmap;
+                                this.customIcon = method.Invoke(null, new object[] { svg, 24, 24 }) as System.Drawing.Bitmap;
                             }
-                            //_customIcon = Rhino.UI.DrawingUtilities.BitmapFromSvg(responseSchema.Icon, 24, 24);
+                            //this.customIcon = Rhino.UI.DrawingUtilities.BitmapFromSvg(responseSchema.Icon, 24, 24);
                         }
-                        if (_customIcon == null)
+                        if (this.customIcon == null)
                         {
                             byte[] bytes = Convert.FromBase64String(responseSchema.Icon);
                             using (var ms = new MemoryStream(bytes))
                             {
-                                _customIcon = new System.Drawing.Bitmap(ms);
-                                if (_customIcon != null && (_customIcon.Width != 24 || _customIcon.Height != 24))
+                                this.customIcon = new System.Drawing.Bitmap(ms);
+                                if (this.customIcon != null && (this.customIcon.Width != 24 || this.customIcon.Height != 24))
                                 {
                                     // Make sure the custom icon is 24x24 which is what GH expects.
-                                    var temp = _customIcon;
-                                    _customIcon = new System.Drawing.Bitmap(temp, new System.Drawing.Size(24, 24));
+                                    var temp = this.customIcon;
+                                    this.customIcon = new System.Drawing.Bitmap(temp, new System.Drawing.Size(24, 24));
                                     temp.Dispose();
                                 }
                             }
@@ -401,8 +401,8 @@ namespace Hops
                 if (!String.IsNullOrEmpty(responseSchema.FileName))
                     fileNameMsg = $" in {responseSchema.FileName}";
                 HopsLog.Log.Debug($"Compute.Geometry found {responseSchema.InputNames?.Count} input{inputSuffix} and {responseSchema.OutputNames?.Count} output{outputSuffix}{fileNameMsg}");
-                _inputParams = new Dictionary<string, Tuple<InputParamSchema, IGH_Param>>();
-                _outputParams = new Dictionary<string, IGH_Param>();
+                inputParams = new Dictionary<string, Tuple<InputParamSchema, IGH_Param>>();
+                outputParams = new Dictionary<string, IGH_Param>();
                 foreach (var input in responseSchema.Inputs)
                 {
                     string inputParamName = input.Name;
@@ -411,7 +411,7 @@ namespace Hops
                         var chunks = inputParamName.Split(new char[] { ':' });
                         inputParamName = chunks[chunks.Length - 1];
                     }
-                    _inputParams[inputParamName] = Tuple.Create(input, ParamFromIoResponseSchema(input));
+                    inputParams[inputParamName] = Tuple.Create(input, ParamFromIoResponseSchema(input));
                 }
                 foreach (var output in responseSchema.Outputs)
                 {
@@ -421,9 +421,9 @@ namespace Hops
                         var chunks = outputParamName.Split(new char[] { ':' });
                         outputParamName = chunks[chunks.Length - 1];
                     }
-                    _outputParams[outputParamName] = ParamFromIoResponseSchema(output);
+                    outputParams[outputParamName] = ParamFromIoResponseSchema(output);
                 }
-                _parentComponent.HTTPRecord.IOResponseSchema = responseSchema;
+                parentComponent.HTTPRecord.IOResponseSchema = responseSchema;
             }
         }
 
@@ -484,23 +484,23 @@ namespace Hops
             }
         }
 
-        static System.Net.Http.HttpClient _httpClient = null;
+        static System.Net.Http.HttpClient httpClient = null;
         public static System.Net.Http.HttpClient HttpClient
         {
             get
             {
-                if (_httpClient == null)
+                if (httpClient == null)
                 {
                     // One shared HttpClient for all requests (avoids per-request socket allocation).
                     // Timeout is intentionally infinite — per-request CancellationTokenSource
                     // controls actual deadlines so HopsAppSettings.HTTPTimeout values larger than
                     // 100s aren't capped by HttpClient's default.
-                    _httpClient = new System.Net.Http.HttpClient
+                    httpClient = new System.Net.Http.HttpClient
                     {
                         Timeout = System.Threading.Timeout.InfiniteTimeSpan
                     };
                 }
-                return _httpClient;
+                return httpClient;
             }
         }
 
@@ -517,7 +517,7 @@ namespace Hops
         static void AddApiKeyHeader(System.Net.Http.HttpRequestMessage request)
         {
             if (!string.IsNullOrEmpty(HopsAppSettings.APIKey))
-                request.Headers.Add(_apiKeyName, HopsAppSettings.APIKey);
+                request.Headers.Add(API_KEY_NAME, HopsAppSettings.APIKey);
         }
         static Schema SafeSchemaDeserialize(string data)
         {
@@ -540,8 +540,8 @@ namespace Hops
             if (pathType == PathType.GrasshopperDefinition || pathType == PathType.ComponentGuid || pathType == PathType.InternalizedDefinition)
             {
                 solveUrl = Servers.GetSolveUrl();
-                if (!string.IsNullOrEmpty(_cacheKey))
-                    inputSchema.Pointer = _cacheKey;
+                if (!string.IsNullOrEmpty(cacheKey))
+                    inputSchema.Pointer = cacheKey;
             }
             else
             {
@@ -549,7 +549,7 @@ namespace Hops
                 solveUrl = $"{uri.Scheme}://{uri.Authority}/solve";
             }
 
-            if (!string.IsNullOrEmpty(_filename)) inputSchema.FileName = _filename;
+            if (!string.IsNullOrEmpty(filename)) inputSchema.FileName = filename;
             string inputJson = JsonConvert.SerializeObject(inputSchema);
             if (useMemoryCache && inputSchema.Algo == null)
             {
@@ -563,7 +563,7 @@ namespace Hops
             requestContent += "\"URL\": \"" + solveUrl + "\"," + Environment.NewLine;
             requestContent += "\"content\": " + inputJson + Environment.NewLine;
             requestContent += "}";
-            _parentComponent.HTTPRecord.SolveRequest = requestContent;
+            parentComponent.HTTPRecord.SolveRequest = requestContent;
             using (var content = new System.Net.Http.StringContent(inputJson, Encoding.UTF8, "application/json"))
             using (var request = new System.Net.Http.HttpRequestMessage(System.Net.Http.HttpMethod.Post, solveUrl) { Content = content })
             using (var cts = CreateTimeoutCts())
@@ -579,7 +579,7 @@ namespace Hops
                 HopsLog.Log.Debug($"Received response {responseMessage.StatusCode} in {sw.ElapsedMilliseconds}ms");
                 var remoteSolvedData = responseMessage.Content;
                 var stringResult = remoteSolvedData.ReadAsStringAsync().Result;
-                _parentComponent.HTTPRecord.SolveResponse = stringResult;
+                parentComponent.HTTPRecord.SolveResponse = stringResult;
                 Schema schema = SafeSchemaDeserialize(stringResult);
                 if (schema == null && responseMessage.StatusCode == System.Net.HttpStatusCode.InternalServerError)
                 {
@@ -596,7 +596,7 @@ namespace Hops
                         requestContent += "\"URL\": \"" + solveUrl + "\"," + Environment.NewLine;
                         requestContent += "\"content\":" + inputJson + Environment.NewLine;
                         requestContent += "}";
-                        _parentComponent.HTTPRecord.SolveRequest = requestContent;
+                        parentComponent.HTTPRecord.SolveRequest = requestContent;
                         using var content2 = new System.Net.Http.StringContent(inputJson, Encoding.UTF8, "application/json");
                         using var request2 = new System.Net.Http.HttpRequestMessage(System.Net.Http.HttpMethod.Post, solveUrl) { Content = content2 };
                         using var cts2 = CreateTimeoutCts();
@@ -611,7 +611,7 @@ namespace Hops
                         HopsLog.Log.Debug($"Received response {responseMessage.StatusCode} in {sw2.ElapsedMilliseconds}ms");
                         remoteSolvedData = responseMessage.Content;
                         stringResult = remoteSolvedData.ReadAsStringAsync().Result;
-                        _parentComponent.HTTPRecord.SolveResponse = stringResult;
+                        parentComponent.HTTPRecord.SolveResponse = stringResult;
                         schema = SafeSchemaDeserialize(stringResult);
                         if (schema == null && responseMessage.StatusCode == System.Net.HttpStatusCode.InternalServerError)
                         {
@@ -620,7 +620,7 @@ namespace Hops
                             HopsLog.Log.Error(errorMsg);
                             badSchema.Errors.Add(errorMsg);
                             badSchema.Warnings.Add(autoUploadMessage);
-                            _parentComponent.HTTPRecord.Schema = badSchema;
+                            parentComponent.HTTPRecord.Schema = badSchema;
                             return badSchema;
                         }
                         if (schema != null)
@@ -634,7 +634,7 @@ namespace Hops
                             var errorMsg = $"Unable to find file: {Path}";
                             HopsLog.Log.Error(errorMsg);
                             badSchema.Errors.Add(errorMsg);
-                            _parentComponent.HTTPRecord.Schema = badSchema;
+                            parentComponent.HTTPRecord.Schema = badSchema;
                             return badSchema;
                         }
                     }
@@ -646,7 +646,7 @@ namespace Hops
                     var errorMsg = $"Request timeout: {Path}";
                     HopsLog.Log.Error(errorMsg);
                     badSchema.Errors.Add(errorMsg);
-                    _parentComponent.HTTPRecord.Schema = badSchema;
+                    parentComponent.HTTPRecord.Schema = badSchema;
                     return badSchema;
                 }
 
@@ -665,7 +665,7 @@ namespace Hops
                         : $"Server returned 401 Unauthorized: {stringResult.Trim()}";
                     HopsLog.Log.Error(serverMessage);
                     badSchema.Errors.Add(serverMessage);
-                    _parentComponent.HTTPRecord.Schema = badSchema;
+                    parentComponent.HTTPRecord.Schema = badSchema;
                     return badSchema;
                 }
 
@@ -674,14 +674,14 @@ namespace Hops
                     && string.Equals(schema?.Errors[0], "Bad inputs", StringComparison.OrdinalIgnoreCase));
                 if (!rebuildDefinition)
                 {
-                    if (schema?.Values?.Count > 0 && schema?.Values?.Count != _outputParams?.Count)
+                    if (schema?.Values?.Count > 0 && schema?.Values?.Count != outputParams?.Count)
                         rebuildDefinition = true;
                 }
 
                 if (rebuildDefinition)
                 {
                     GetRemoteDescription();
-                    _parentComponent.OnRemoteDefinitionChanged();
+                    parentComponent.OnRemoteDefinitionChanged();
                 }
                 else
                 {
@@ -693,7 +693,7 @@ namespace Hops
                         }
                     }
                 }
-                _cacheKey = schema?.Pointer;
+                cacheKey = schema?.Pointer;
                 return schema;
             }
         }
@@ -937,50 +937,50 @@ namespace Hops
             };
         }
 
-        static List<IGH_Param> _params;
+        static List<IGH_Param> parameters;
         static IGH_Param ParamFromIoResponseSchema(IoParamSchema item)
         {
-            if (_params == null)
+            if (parameters == null)
             {
-                _params = new List<IGH_Param>();
-                _params.Add(new Grasshopper.Kernel.Parameters.Param_Arc());
-                _params.Add(new Grasshopper.Kernel.Parameters.Param_Boolean());
-                _params.Add(new Grasshopper.Kernel.Parameters.Param_Box());
-                _params.Add(new Grasshopper.Kernel.Parameters.Param_Brep());
-                _params.Add(new Grasshopper.Kernel.Parameters.Param_Circle());
-                _params.Add(new Grasshopper.Kernel.Parameters.Param_Colour());
-                _params.Add(new Grasshopper.Kernel.Parameters.Param_Complex());
-                _params.Add(new Grasshopper.Kernel.Parameters.Param_Culture());
-                _params.Add(new Grasshopper.Kernel.Parameters.Param_Curve());
-                _params.Add(new Grasshopper.Kernel.Parameters.Param_Field());
+                parameters = new List<IGH_Param>();
+                parameters.Add(new Grasshopper.Kernel.Parameters.Param_Arc());
+                parameters.Add(new Grasshopper.Kernel.Parameters.Param_Boolean());
+                parameters.Add(new Grasshopper.Kernel.Parameters.Param_Box());
+                parameters.Add(new Grasshopper.Kernel.Parameters.Param_Brep());
+                parameters.Add(new Grasshopper.Kernel.Parameters.Param_Circle());
+                parameters.Add(new Grasshopper.Kernel.Parameters.Param_Colour());
+                parameters.Add(new Grasshopper.Kernel.Parameters.Param_Complex());
+                parameters.Add(new Grasshopper.Kernel.Parameters.Param_Culture());
+                parameters.Add(new Grasshopper.Kernel.Parameters.Param_Curve());
+                parameters.Add(new Grasshopper.Kernel.Parameters.Param_Field());
                 //FilePath has the same ParamType as String
-                //_params.Add(new Grasshopper.Kernel.Parameters.Param_FilePath());
-                _params.Add(new Grasshopper.Kernel.Parameters.Param_GenericObject());
-                _params.Add(new Grasshopper.Kernel.Parameters.Param_Geometry());
-                _params.Add(new Grasshopper.Kernel.Parameters.Param_Group());
-                _params.Add(new Grasshopper.Kernel.Parameters.Param_Guid());
-                _params.Add(new Grasshopper.Kernel.Parameters.Param_Integer());
-                _params.Add(new Grasshopper.Kernel.Parameters.Param_Interval());
-                _params.Add(new Grasshopper.Kernel.Parameters.Param_Interval2D());
-                _params.Add(new Grasshopper.Kernel.Parameters.Param_LatLonLocation());
-                _params.Add(new Grasshopper.Kernel.Parameters.Param_Line());
-                _params.Add(new Grasshopper.Kernel.Parameters.Param_Matrix());
-                _params.Add(new Grasshopper.Kernel.Parameters.Param_Mesh());
-                _params.Add(new Grasshopper.Kernel.Parameters.Param_MeshFace());
-                _params.Add(new Grasshopper.Kernel.Parameters.Param_MeshParameters());
-                _params.Add(new Grasshopper.Kernel.Parameters.Param_Number());
-                _params.Add(new Grasshopper.Kernel.Parameters.Param_Plane());
-                _params.Add(new Grasshopper.Kernel.Parameters.Param_Point());
-                _params.Add(new Grasshopper.Kernel.Parameters.Param_Rectangle());
-                _params.Add(new Grasshopper.Kernel.Parameters.Param_String());
-                _params.Add(new Grasshopper.Kernel.Parameters.Param_StructurePath());
-                _params.Add(new Grasshopper.Kernel.Parameters.Param_SubD());
-                _params.Add(new Grasshopper.Kernel.Parameters.Param_Surface());
-                _params.Add(new Grasshopper.Kernel.Parameters.Param_Time());
-                _params.Add(new Grasshopper.Kernel.Parameters.Param_Transform());
-                _params.Add(new Grasshopper.Kernel.Parameters.Param_Vector());
+                //parameters.Add(new Grasshopper.Kernel.Parameters.Param_FilePath());
+                parameters.Add(new Grasshopper.Kernel.Parameters.Param_GenericObject());
+                parameters.Add(new Grasshopper.Kernel.Parameters.Param_Geometry());
+                parameters.Add(new Grasshopper.Kernel.Parameters.Param_Group());
+                parameters.Add(new Grasshopper.Kernel.Parameters.Param_Guid());
+                parameters.Add(new Grasshopper.Kernel.Parameters.Param_Integer());
+                parameters.Add(new Grasshopper.Kernel.Parameters.Param_Interval());
+                parameters.Add(new Grasshopper.Kernel.Parameters.Param_Interval2D());
+                parameters.Add(new Grasshopper.Kernel.Parameters.Param_LatLonLocation());
+                parameters.Add(new Grasshopper.Kernel.Parameters.Param_Line());
+                parameters.Add(new Grasshopper.Kernel.Parameters.Param_Matrix());
+                parameters.Add(new Grasshopper.Kernel.Parameters.Param_Mesh());
+                parameters.Add(new Grasshopper.Kernel.Parameters.Param_MeshFace());
+                parameters.Add(new Grasshopper.Kernel.Parameters.Param_MeshParameters());
+                parameters.Add(new Grasshopper.Kernel.Parameters.Param_Number());
+                parameters.Add(new Grasshopper.Kernel.Parameters.Param_Plane());
+                parameters.Add(new Grasshopper.Kernel.Parameters.Param_Point());
+                parameters.Add(new Grasshopper.Kernel.Parameters.Param_Rectangle());
+                parameters.Add(new Grasshopper.Kernel.Parameters.Param_String());
+                parameters.Add(new Grasshopper.Kernel.Parameters.Param_StructurePath());
+                parameters.Add(new Grasshopper.Kernel.Parameters.Param_SubD());
+                parameters.Add(new Grasshopper.Kernel.Parameters.Param_Surface());
+                parameters.Add(new Grasshopper.Kernel.Parameters.Param_Time());
+                parameters.Add(new Grasshopper.Kernel.Parameters.Param_Transform());
+                parameters.Add(new Grasshopper.Kernel.Parameters.Param_Vector());
             }
-            foreach(var p in _params)
+            foreach(var p in parameters)
             {
                 if (p.TypeName.Equals(item.ParamType, StringComparison.OrdinalIgnoreCase))
                 {
@@ -1296,7 +1296,7 @@ namespace Hops
             schema.AbsoluteTolerance = GetDocumentTolerance();
             schema.AngleTolerance = GetDocumentAngleTolerance();
             schema.ModelUnits = GetDocumentUnits();
-            schema.FileName = _filename;
+            schema.FileName = filename;
             schema.CacheSolve = cacheSolveOnServer;
             var inputs = GetInputParams();
             if (inputs != null)
@@ -1319,111 +1319,111 @@ namespace Hops
                     switch (param)
                     {
                         case Grasshopper.Kernel.Parameters.Param_Arc _:
-                            CollectDataHelperWithTree<Arc, GH_Arc>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
+                            CollectDataHelperWithTree<Arc, GH_Arc>(DA, parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Boolean _:
-                            CollectDataHelperWithTree<bool, GH_Boolean>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
+                            CollectDataHelperWithTree<bool, GH_Boolean>(DA, parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Box _:
-                            CollectDataHelperWithTree<Box, GH_Box>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
+                            CollectDataHelperWithTree<Box, GH_Box>(DA, parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Brep _:
-                            CollectDataHelperWithTree<Brep, GH_Brep>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
+                            CollectDataHelperWithTree<Brep, GH_Brep>(DA, parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Circle _:
-                            CollectDataHelperWithTree<Circle, GH_Circle>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
+                            CollectDataHelperWithTree<Circle, GH_Circle>(DA, parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Colour _:
-                            CollectDataHelperWithTree<System.Drawing.Color, GH_Colour>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
+                            CollectDataHelperWithTree<System.Drawing.Color, GH_Colour>(DA, parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Complex _:
-                            CollectDataHelperWithTree<Complex, GH_ComplexNumber>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
+                            CollectDataHelperWithTree<Complex, GH_ComplexNumber>(DA, parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Culture _:
-                            CollectDataHelperWithTree<System.Globalization.CultureInfo, GH_Culture>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
+                            CollectDataHelperWithTree<System.Globalization.CultureInfo, GH_Culture>(DA, parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Curve _:
-                            CollectDataHelperWithTree<Curve, GH_Curve>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
+                            CollectDataHelperWithTree<Curve, GH_Curve>(DA, parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Field _:
-                            CollectDataHelper<Grasshopper.Kernel.Types.GH_Field>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
+                            CollectDataHelper<Grasshopper.Kernel.Types.GH_Field>(DA, parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_FilePath _:
-                            CollectDataHelperWithTree<string, GH_String>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
+                            CollectDataHelperWithTree<string, GH_String>(DA, parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_GenericObject _:
                             throw new Exception("generic param not supported");
                         case Grasshopper.Kernel.Parameters.Param_Geometry _:
-                            CollectDataHelperGeometryBase<IGH_GeometricGoo>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
+                            CollectDataHelperGeometryBase<IGH_GeometricGoo>(DA, parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Group _:
                             throw new Exception("group param not supported");
                         case Grasshopper.Kernel.Parameters.Param_Guid _:
-                            CollectDataHelperWithTree<Guid, GH_Guid>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
+                            CollectDataHelperWithTree<Guid, GH_Guid>(DA, parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Integer _:
-                            CollectDataHelperWithTree<int, GH_Integer>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
+                            CollectDataHelperWithTree<int, GH_Integer>(DA, parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Interval _:
-                            CollectDataHelperWithTree<Interval, GH_Interval>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
+                            CollectDataHelperWithTree<Interval, GH_Interval>(DA, parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Interval2D _:
-                            CollectDataHelperWithTree<UVInterval, GH_Interval2D>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
+                            CollectDataHelperWithTree<UVInterval, GH_Interval2D>(DA, parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_LatLonLocation _:
                             throw new Exception("latlonlocation param not supported");
                         case Grasshopper.Kernel.Parameters.Param_Line _:
-                            CollectDataHelperWithTree<Line, GH_Line>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
+                            CollectDataHelperWithTree<Line, GH_Line>(DA, parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Matrix _:
-                            CollectDataHelperWithTree<Matrix, GH_Matrix>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
+                            CollectDataHelperWithTree<Matrix, GH_Matrix>(DA, parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Mesh _:
-                            CollectDataHelperWithTree<Mesh, GH_Mesh>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
+                            CollectDataHelperWithTree<Mesh, GH_Mesh>(DA, parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_MeshFace _:
-                            CollectDataHelperWithTree<MeshFace, GH_MeshFace>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
+                            CollectDataHelperWithTree<MeshFace, GH_MeshFace>(DA, parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_MeshParameters _:
-                            CollectDataHelperWithTree<MeshingParameters, GH_MeshingParameters>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
+                            CollectDataHelperWithTree<MeshingParameters, GH_MeshingParameters>(DA, parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Number _:
-                            CollectDataHelperWithTree<double, GH_Number>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
+                            CollectDataHelperWithTree<double, GH_Number>(DA, parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         //case Grasshopper.Kernel.Parameters.Param_OGLShader:
                         case Grasshopper.Kernel.Parameters.Param_Plane _:
-                            CollectDataHelperWithTree<Plane, GH_Plane>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
+                            CollectDataHelperWithTree<Plane, GH_Plane>(DA, parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Point _:
-                            CollectDataHelperPoints<Point3d>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
+                            CollectDataHelperPoints<Point3d>(DA, parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Rectangle _:
-                            CollectDataHelperWithTree<Rectangle3d, GH_Rectangle>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
+                            CollectDataHelperWithTree<Rectangle3d, GH_Rectangle>(DA, parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         //case Grasshopper.Kernel.Parameters.Param_ScriptVariable _:
                         case Grasshopper.Kernel.Parameters.Param_String _:
-                            CollectDataHelperWithTree<string, GH_String>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
+                            CollectDataHelperWithTree<string, GH_String>(DA, parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_StructurePath _:
-                            CollectDataHelperWithTree<Grasshopper.Kernel.Data.GH_Path, GH_StructurePath>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
+                            CollectDataHelperWithTree<Grasshopper.Kernel.Data.GH_Path, GH_StructurePath>(DA, parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_SubD _:
-                            CollectDataHelperWithTree<SubD, GH_SubD>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
+                            CollectDataHelperWithTree<SubD, GH_SubD>(DA, parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Surface _:
-                            CollectDataHelper<Surface>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
+                            CollectDataHelper<Surface>(DA, parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Time _:
-                            CollectDataHelperWithTree<DateTime, GH_Time>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
+                            CollectDataHelperWithTree<DateTime, GH_Time>(DA, parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Transform _:
-                            CollectDataHelperWithTree<Transform, GH_Transform>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
+                            CollectDataHelperWithTree<Transform, GH_Transform>(DA, parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Parameters.Param_Vector _:
-                            CollectDataHelperWithTree<Vector3d, GH_Vector>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
+                            CollectDataHelperWithTree<Vector3d, GH_Vector>(DA, parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                         case Grasshopper.Kernel.Special.GH_NumberSlider _:
-                            CollectDataHelperWithTree<double, GH_Number>(DA, _parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
+                            CollectDataHelperWithTree<double, GH_Number>(DA, parentComponent, inputName, input, access, ref inputListCount, dataTree, ref errors);
                             break;
                     }
 
@@ -1452,7 +1452,7 @@ namespace Hops
                 var pointer = new Uri(Path).AbsolutePath;
                 schema.Pointer = pointer.Substring(1);
             }
-            _parentComponent.HTTPRecord.Schema = schema;
+            parentComponent.HTTPRecord.Schema = schema;
             return schema;
         }
     }
@@ -1460,9 +1460,9 @@ namespace Hops
 
     static class RemoteDefinitionCache
     {
-        static List<RemoteDefinition> _definitions = new List<RemoteDefinition>();
-        static Dictionary<string, FileSystemWatcher> _filewatchers;
-        static HashSet<string> _watchedFiles = new HashSet<string>();
+        static List<RemoteDefinition> definitions = new List<RemoteDefinition>();
+        static Dictionary<string, FileSystemWatcher> filewatchers;
+        static HashSet<string> watchedFiles = new HashSet<string>();
 
         public static void Add(RemoteDefinition definition)
         {
@@ -1473,20 +1473,20 @@ namespace Hops
                 return;
             if (!File.Exists(definition.Path))
                 return;
-            if (_definitions.Contains(definition))
+            if (definitions.Contains(definition))
                 return;
-            _definitions.Add(definition);
+            definitions.Add(definition);
             RegisterFileWatcher(definition.Path);
         }
 
         public static void Remove(RemoteDefinition definition)
         {
-            if (_definitions.Remove(definition) && definition.Path != null)
+            if (definitions.Remove(definition) && definition.Path != null)
             {
                 string path = Path.GetFullPath(definition.Path);
                 string directory = Path.GetDirectoryName(path);
                 bool removeFileWatcher = true;
-                foreach(var existingDefinition in _definitions)
+                foreach(var existingDefinition in definitions)
                 {
                     string existingDefPath = Path.GetFullPath(existingDefinition.Path);
                     string existingDefDirectory = Path.GetDirectoryName(existingDefPath);
@@ -1498,11 +1498,11 @@ namespace Hops
                 }
                 if (removeFileWatcher)
                 {
-                    if (_filewatchers.TryGetValue(directory, out FileSystemWatcher watcher))
+                    if (filewatchers.TryGetValue(directory, out FileSystemWatcher watcher))
                     {
                         watcher.EnableRaisingEvents = false;
                         watcher.Dispose();
-                        _filewatchers.Remove(directory);
+                        filewatchers.Remove(directory);
                     }
                 }
             }
@@ -1513,18 +1513,18 @@ namespace Hops
             if (!File.Exists(path))
                 return;
 
-            if (_filewatchers == null)
+            if (filewatchers == null)
             {
-                _filewatchers = new Dictionary<string, FileSystemWatcher>();
+                filewatchers = new Dictionary<string, FileSystemWatcher>();
             }
 
             path = Path.GetFullPath(path);
-            if (_watchedFiles.Contains(path.ToLowerInvariant()))
+            if (watchedFiles.Contains(path.ToLowerInvariant()))
                 return;
 
-            _watchedFiles.Add(path.ToLowerInvariant());
+            watchedFiles.Add(path.ToLowerInvariant());
             string directory = Path.GetDirectoryName(path);
-            if (_filewatchers.ContainsKey(directory) || !Directory.Exists(directory))
+            if (filewatchers.ContainsKey(directory) || !Directory.Exists(directory))
                 return;
 
             var fsw = new FileSystemWatcher(directory);
@@ -1537,15 +1537,15 @@ namespace Hops
                 NotifyFilters.Security;
             fsw.Changed += Fsw_Changed;
             fsw.EnableRaisingEvents = true;
-            _filewatchers[directory] = fsw;
+            filewatchers[directory] = fsw;
         }
 
         private static void Fsw_Changed(object sender, FileSystemEventArgs e)
         {
             string path = e.FullPath.ToLowerInvariant();
-            if (_watchedFiles.Contains(path))
+            if (watchedFiles.Contains(path))
             {
-                foreach(var definition in _definitions)
+                foreach(var definition in definitions)
                 {
                     string definitionPath = Path.GetFullPath(definition.Path);
                     if( path.Equals(definitionPath, StringComparison.OrdinalIgnoreCase))

--- a/src/hops/Servers.cs
+++ b/src/hops/Servers.cs
@@ -15,14 +15,14 @@ namespace Hops
     /// </summary>
     class Servers
     {
-        static System.Threading.Tasks.Task<bool> _initServerTask;
+        static System.Threading.Tasks.Task<bool> initServerTask;
         public static void StartServerOnLaunch()
         {
-            _initServerTask = System.Threading.Tasks.Task.Run(() =>
+            initServerTask = System.Threading.Tasks.Task.Run(() =>
             {
-                lock (_lockObject)
+                lock (lockObject)
                 {
-                    LaunchLocalRhinoCompute(_computeServerQueue, true);
+                    LaunchLocalRhinoCompute(computeServerQueue, true);
                 }
                 return true;
             });
@@ -30,7 +30,7 @@ namespace Hops
 
         public static void SettingsChanged()
         {
-            _settingsNeedReading = true;
+            settingsNeedReading = true;
         }
 
         /// <summary>Number of local compute.geometry processes running</summary>
@@ -77,59 +77,59 @@ namespace Hops
         /// <returns></returns>
         static string GetComputeServerBaseUrl()
         {
-            if (_initServerTask != null)
+            if (initServerTask != null)
             {
-                _initServerTask.Wait();
-                _initServerTask = null;
+                initServerTask.Wait();
+                initServerTask = null;
             }
             // Simple round robin scheduler using a queue of compute.geometry processes
             string url = null;
 
-            lock (_lockObject)
+            lock (lockObject)
             {
                 // Check application level settings to see if there are remote
                 // compute servers defined.
-                if (_settingsNeedReading)
+                if (settingsNeedReading)
                 {
-                    _settingsNeedReading = false;
+                    settingsNeedReading = false;
                     string[] servers = Hops.HopsAppSettings.Servers;
-                    var serverArray = _computeServerQueue.ToArray();
-                    _computeServerQueue.Clear();
+                    var serverArray = computeServerQueue.ToArray();
+                    computeServerQueue.Clear();
                     foreach (var server in servers)
                     {
                         if (string.IsNullOrWhiteSpace(server))
                             continue;
-                        _computeServerQueue.Enqueue(new ComputeServer(server));
+                        computeServerQueue.Enqueue(new ComputeServer(server));
                     }
                     foreach(var item in serverArray)
                     {
                         if (item.IsLocalProcess)
-                            _computeServerQueue.Enqueue(item);
+                            computeServerQueue.Enqueue(item);
                     }
                 }
 
-                if (_computeServerQueue.Count > 0)
+                if (computeServerQueue.Count > 0)
                 {
-                    var current = _computeServerQueue.Dequeue();
+                    var current = computeServerQueue.Dequeue();
                     url = current.GetUrl();
                     if( !string.IsNullOrEmpty(url))
                     {
-                        _computeServerQueue.Enqueue(current);
+                        computeServerQueue.Enqueue(current);
                     }
                 }
 
                 if (string.IsNullOrEmpty(url) && Rhino.Runtime.HostUtils.RunningOnWindows)
                 {
-                    _computeServerQueue = new Queue<ComputeServer>();
-                    if (_computeServerQueue.Count == 0)
+                    computeServerQueue = new Queue<ComputeServer>();
+                    if (computeServerQueue.Count == 0)
                     {
-                        LaunchLocalRhinoCompute(_computeServerQueue, true);
+                        LaunchLocalRhinoCompute(computeServerQueue, true);
                     }
 
-                    if (_computeServerQueue.Count > 0)
+                    if (computeServerQueue.Count > 0)
                     {
-                        var current = _computeServerQueue.Dequeue();
-                        _computeServerQueue.Enqueue(current);
+                        var current = computeServerQueue.Dequeue();
+                        computeServerQueue.Enqueue(current);
                         url = current.GetUrl();
                     }
                 }
@@ -283,54 +283,54 @@ namespace Hops
             }
         }
 
-        static object _lockObject = new Object();
-        static Queue<ComputeServer> _computeServerQueue = new Queue<ComputeServer>();
-        static bool _settingsNeedReading = true;
+        static object lockObject = new Object();
+        static Queue<ComputeServer> computeServerQueue = new Queue<ComputeServer>();
+        static bool settingsNeedReading = true;
 
         class ComputeServer
         {
-            readonly Process _process;
-            readonly int _port;
-            readonly string _url;
+            readonly Process process;
+            readonly int port;
+            readonly string url;
             public ComputeServer(Process proc, int port)
             {
-                _process = proc;
-                _port = port;
-                _url = null;
+                process = proc;
+                this.port = port;
+                url = null;
             }
             public ComputeServer(string url)
             {
-                _process = null;
-                _port = 0;
-                _url = url.Trim(new char[] { '/' });
+                process = null;
+                port = 0;
+                this.url = url.Trim(new char[] { '/' });
             }
 
             public bool IsLocalProcess
             {
-                get { return _process != null; }
+                get { return process != null; }
             }
 
             public bool IsProcess(Process proc)
             {
-                if (_process == null)
+                if (process == null)
                     return false;
 
-                return _process.Id == proc.Id;
+                return process.Id == proc.Id;
             }
             public int LocalProcessPort()
             {
-                return _port;
+                return port;
             }
 
             public string GetUrl()
             {
-                if(_process != null)
+                if(process != null)
                 {
-                    if (_process.HasExited)
+                    if (process.HasExited)
                         return null;
-                    return $"http://localhost:{_port}";
+                    return $"http://localhost:{port}";
                 }
-                return _url;
+                return url;
             }
         }
     }

--- a/src/hops/SolveData.cs
+++ b/src/hops/SolveData.cs
@@ -6,11 +6,11 @@ namespace Hops
 {
     class SolveData
     {
-        readonly Resthopper.IO.Schema _input;
+        readonly Resthopper.IO.Schema input;
 
         public SolveData(Resthopper.IO.Schema input)
         {
-            _input = input;
+            this.input = input;
         }
 
         public bool HasSolveData
@@ -23,84 +23,84 @@ namespace Hops
 
         public Resthopper.IO.Schema Output { get; private set; }
 
-        Task _workingTask;
+        Task workingTask;
         public Task Solve(RemoteDefinition remoteDefinition, bool useMemoryCache, Action completedCallback)
         {
-            _workingTask = Task.Run(() =>
+            workingTask = Task.Run(() =>
             {
-                Output = remoteDefinition.Solve(_input, useMemoryCache);
+                Output = remoteDefinition.Solve(input, useMemoryCache);
                 completedCallback();
             });
-            return _workingTask;
+            return workingTask;
         }
     }
 
     class SolveDataList
     {
-        readonly int _solveSerialNumber;
-        readonly HopsComponent _parentComponent;
-        readonly bool _useMemoryCacheWhenSolving;
-        readonly RemoteDefinition _remoteDefinition;
-        bool _synchronous = false;
+        readonly int solveSerialNumber;
+        readonly HopsComponent parentComponent;
+        readonly bool useMemoryCacheWhenSolving;
+        readonly RemoteDefinition remoteDefinition;
+        bool synchronous = false;
 
-        List<SolveData> _data = new List<SolveData>();
-        bool _solveStarted = false;
+        List<SolveData> data = new List<SolveData>();
+        bool solveStarted = false;
 
         public SolveDataList(int serialNumber, HopsComponent component, RemoteDefinition remoteDefinition, bool useMemoryCache)
         {
-            _solveSerialNumber = serialNumber;
-            _parentComponent = component;
-            _useMemoryCacheWhenSolving = useMemoryCache;
-            _remoteDefinition = remoteDefinition;
+            solveSerialNumber = serialNumber;
+            parentComponent = component;
+            useMemoryCacheWhenSolving = useMemoryCache;
+            this.remoteDefinition = remoteDefinition;
         }
 
         public void Add(Resthopper.IO.Schema inputSchema)
         {
-            _data.Add(new SolveData(inputSchema));
+            data.Add(new SolveData(inputSchema));
         }
 
         public void StartSolving(bool waitUntilComplete)
         {
-            if (_solveStarted || Canceled)
+            if (solveStarted || Canceled)
                 return;
-            _solveStarted = true;
-            _synchronous = waitUntilComplete;
+            solveStarted = true;
+            synchronous = waitUntilComplete;
 
             SolveIterationQueue.Add(this);
         }
 
-        public int Count => _data.Count;
+        public int Count => data.Count;
         public bool Canceled { get; set; } = false;
-        public bool Synchronous => _synchronous;
+        public bool Synchronous => synchronous;
 
         public Task Solve(int index)
         {
             if (Canceled)
                 return null;
 
-            return _data[index].Solve(_remoteDefinition, _useMemoryCacheWhenSolving, OnItemSolved);
+            return data[index].Solve(remoteDefinition, useMemoryCacheWhenSolving, OnItemSolved);
         }
 
-        int _solvedCount = 0;
+        int solvedCount = 0;
         void OnItemSolved()
         {
-            System.Threading.Interlocked.Increment(ref _solvedCount);
-            if (_solvedCount == _data.Count && !_synchronous)
+            System.Threading.Interlocked.Increment(ref solvedCount);
+            if (solvedCount == data.Count && !synchronous)
             {
-                SolveIterationQueue.AddIdleCallback(_parentComponent.InstanceGuid, () => _parentComponent.OnWorkingListComplete());
+                SolveIterationQueue.AddIdleCallback(parentComponent.InstanceGuid, () => parentComponent.OnWorkingListComplete());
             }
         }
         private void RhinoApp_Idle(object sender, EventArgs e)
         {
-            if (_solveSerialNumber != _parentComponent.SolveSerialNumber || Canceled)
+            if (solveSerialNumber != parentComponent.SolveSerialNumber || Canceled)
             {
                 Rhino.RhinoApp.Idle -= RhinoApp_Idle;
                 return;
             }
 
-            if (SolvedFor(_parentComponent.SolveSerialNumber))
+            if (SolvedFor(parentComponent.SolveSerialNumber))
             {
-                _parentComponent.ExpireSolution(true);
+                parentComponent.ExpireSolution(true);
                 Rhino.RhinoApp.Idle -= RhinoApp_Idle;
             }
         }
@@ -108,14 +108,14 @@ namespace Hops
 
         public Resthopper.IO.Schema SolvedSchema(int index)
         {
-            return _data[index].Output;
+            return data[index].Output;
         }
 
         public bool SolvedFor(int serialNumber)
         {
-            if (!_solveStarted || _solveSerialNumber != serialNumber)
+            if (!solveStarted || solveSerialNumber != serialNumber)
                 return false;
-            foreach(var item in _data)
+            foreach(var item in data)
             {
                 if (!item.HasSolveData)
                     return false;

--- a/src/hops/SolveIterationQueue.cs
+++ b/src/hops/SolveIterationQueue.cs
@@ -7,20 +7,20 @@ namespace Hops
 {
     static class SolveIterationQueue
     {
-        static Task _solveTask;
-        static ConcurrentStack<SolveDataList> _stack = new ConcurrentStack<SolveDataList>();
-        static int _maxConcurrentRequests;
-        static bool _idleSet = false;
-        static ConcurrentDictionary<Guid, Action> _componentCallbacks = new ConcurrentDictionary<Guid, Action>();
+        static Task solveTask;
+        static ConcurrentStack<SolveDataList> stack = new ConcurrentStack<SolveDataList>();
+        static int maxConcurrentRequests;
+        static bool idleSet = false;
+        static ConcurrentDictionary<Guid, Action> componentCallbacks = new ConcurrentDictionary<Guid, Action>();
 
         static public void Add(SolveDataList datalist)
         {
-            if (!_idleSet && !datalist.Synchronous)
+            if (!idleSet && !datalist.Synchronous)
             {
-                _idleSet = true;
+                idleSet = true;
                 Rhino.RhinoApp.Idle += RhinoApp_Idle;
             }
-            _maxConcurrentRequests = HopsAppSettings.MaxConcurrentRequests;
+            maxConcurrentRequests = HopsAppSettings.MaxConcurrentRequests;
 
             if (datalist.Synchronous)
             {
@@ -31,24 +31,24 @@ namespace Hops
                 return;
             }
 
-            _stack.Push(datalist);
-            if (_solveTask == null || _solveTask.IsCompleted)
-                _solveTask = Task.Run(() => ProcessStack(_stack));
+            stack.Push(datalist);
+            if (solveTask == null || solveTask.IsCompleted)
+                solveTask = Task.Run(() => ProcessStack(stack));
         }
 
         private static void RhinoApp_Idle(object sender, System.EventArgs e)
         {
-            if (_stack.Count > 0 && (_solveTask == null || _solveTask.IsCompleted))
-                _solveTask = Task.Run(() => ProcessStack(_stack));
+            if (stack.Count > 0 && (solveTask == null || solveTask.IsCompleted))
+                solveTask = Task.Run(() => ProcessStack(stack));
 
-            foreach (var callback in _componentCallbacks.Values)
+            foreach (var callback in componentCallbacks.Values)
                 callback();
-            _componentCallbacks.Clear();
+            componentCallbacks.Clear();
         }
 
         public static void AddIdleCallback(Guid componentId, System.Action callback)
         {
-            _componentCallbacks[componentId] = callback;
+            componentCallbacks[componentId] = callback;
         }
 
         static void ProcessStack(ConcurrentStack<SolveDataList> stack)
@@ -63,7 +63,7 @@ namespace Hops
                     if (t != null)
                     {
                         childTasks.Add(t);
-                        if (childTasks.Count >= _maxConcurrentRequests)
+                        if (childTasks.Count >= maxConcurrentRequests)
                         {
                             var taskArray = childTasks.ToArray();
                             Task.WaitAny(childTasks.ToArray());


### PR DESCRIPTION
## Summary
  Naming-convention cleanup for the Hops project — the counterpart to #898 (which
  covered rhino.compute + compute.geometry). Removes underscore prefixes to match
  the house style: private fields/locals/params → `lowerCamelCase`, consts →
  `SCREAMING_SNAKE_CASE`. Pure refactor; no behavior change.

  10 files: Config, MemoryCache, FunctionPathInfo, HopsAppSettings, HopsFunctionMgr,
  Servers, SolveData, SolveIterationQueue, HopsComponent, RemoteDefinition.

  ### Collision-safe handling
  - Constructor/param clashes qualified with `this.` (SolveData `input`/`remoteDefinition`,
    Servers `ComputeServer` ctors incl. the silent `this.url = url.Trim(...)` case,
    RemoteDefinition ctor `parentComponent`/`path`, HopsComponent `synchronous`).
  - `RemoteDefinition.GetDescription` has an `out customIcon` param and a local
    `pathType` that shadow fields, so those field accesses are qualified with `this.`.
  - Field-read-into-same-named-local fixed (HopsComponent `bool synchronous = this.synchronous;`).
  - Keyword/const: `_params` → `parameters` (can't be `params`); `_apiKeyName` → `API_KEY_NAME`.
  - Cross-file: `_pathType` renamed in RemoteDefinition.cs and its external use in
    HopsComponent.cs (`remoteDefinition.pathType`).

  ### Out of scope (intentionally untouched)
  - The WinForms settings control pair: `HopsAppSettingsUserControl.cs` +
    `HopsAppSettingsUserControl.Designer.cs` (auto-generated; control fields keep `_`).
  - `GH_Variant._Int` (external Grasshopper member); the `"_Path"`/`"_Enabled"`
    Grasshopper input-name string literals; commented-out dead code.

  ## Test plan
  - [x] Hops builds clean (0 warnings/errors; no CS1717/CS1718 → no rename collided).
  - [x] In Grasshopper: Function Source Manager (local directory) builds the menu and
        loads a definition; URL in the Path input solves correctly.