### PR TITLE
Surface remote-definition load failures as clear Hops errors

### DIFF
--- a/src/compute.geometry/GrasshopperDefinition.cs
+++ b/src/compute.geometry/GrasshopperDefinition.cs
@@ -712,7 +712,18 @@ namespace compute.geometry
                 // UrlGuard validates scheme + optional private-IP block, then streams the
                 // response with a size cap from Config.MaxRequestSize. HttpClientHelper.Client
                 // (used by UrlGuard under the hood) has GZip/Deflate decompression enabled.
-                byte[] byteArray = UrlGuard.GetByteArrayAsync(url, Config.MaxRequestSize).Result;
+                // Unwrap the AggregateException that .Result wraps around the real failure so
+                // the clean inner message (e.g. "The server responded with 503 ...") surfaces
+                // instead of "One or more errors occurred. (...)".
+                byte[] byteArray;
+                try
+                {
+                    byteArray = UrlGuard.GetByteArrayAsync(url, Config.MaxRequestSize).Result;
+                }
+                catch (AggregateException ex) when (ex.InnerException != null)
+                {
+                    throw ex.InnerException;
+                }
 
                 try
                 {

--- a/src/compute.geometry/UrlGuard.cs
+++ b/src/compute.geometry/UrlGuard.cs
@@ -84,7 +84,12 @@ namespace compute.geometry
             using var response = await HttpClientHelper.Client
                 .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct)
                 .ConfigureAwait(false);
-            response.EnsureSuccessStatusCode();
+            // Surface the source server's own status in a clean message rather than the
+            // generic EnsureSuccessStatusCode text ("Response status code does not indicate
+            // success: ..."), so callers can show the user exactly what the remote URL returned.
+            if (!response.IsSuccessStatusCode)
+                throw new HttpRequestException(
+                    $"The server responded with {(int)response.StatusCode} ({response.StatusCode}).");
 
             if (response.Content.Headers.ContentLength is long len && len > maxBytes)
                 throw new InvalidOperationException(

--- a/src/hops/HopsComponent.cs
+++ b/src/hops/HopsComponent.cs
@@ -201,6 +201,18 @@ namespace Hops
                 return;
             }
 
+            // The remote definition failed to load its IO description (e.g. the server errored
+            // while fetching the definition). DefineInputsAndOutputs surfaces this when the
+            // location is set, but Grasshopper clears runtime messages at the start of every
+            // solve — so re-surface it here, during SolveInstance, where it survives to render.
+            // Skip solving a definition that never loaded.
+            if (HTTPRecord.IOResponseSchema != null && HTTPRecord.IOResponseSchema.Errors.Count > 0)
+            {
+                foreach (var error in HTTPRecord.IOResponseSchema.Errors)
+                    HopsAddRuntimeMessage(GH_RuntimeMessageLevel.Error, error);
+                return;
+            }
+
             if (showEnabledInput && DA.Iteration == 0)
             {
                 bool enabled = true;
@@ -685,7 +697,7 @@ namespace Hops
                     catch (Exception) { }
                     break;
             }
-            
+
         }
 
         private void tsm_UriClick(object sender, MouseEventArgs e)

--- a/src/hops/RemoteDefinition.cs
+++ b/src/hops/RemoteDefinition.cs
@@ -53,6 +53,36 @@ namespace Hops
             }
             return false;
         }
+
+        // Pull the human-readable "message" out of compute's JSON error body
+        // ({"error":...,"message":"...","stackTrace":[...]}) so the component shows a clean
+        // message instead of the raw JSON + stack trace. Falls back to the trimmed body for
+        // non-JSON responses (e.g. a plain-text 401).
+        static string ExtractServerErrorMessage(string body)
+        {
+            if (string.IsNullOrWhiteSpace(body))
+                return null;
+            string message = body.Trim();
+            try
+            {
+                if (Newtonsoft.Json.Linq.JToken.Parse(body) is Newtonsoft.Json.Linq.JObject obj)
+                {
+                    var m = obj["message"]?.ToString();
+                    if (!string.IsNullOrWhiteSpace(m))
+                        message = m;
+                }
+            }
+            catch (Exception)
+            {
+                // not JSON — keep the raw body
+            }
+            // compute.geometry's global exception handler prefixes unrecognized exception types
+            // with the type name (e.g. "HttpRequestException: ..."); strip it so the text is clean.
+            var match = System.Text.RegularExpressions.Regex.Match(message, @"^[A-Za-z0-9_.]+Exception:\s*");
+            if (match.Success)
+                message = message.Substring(match.Length);
+            return message;
+        }
         private static bool IsGrasshopperDefinition(string filename)
         {
             if (!String.IsNullOrEmpty(filename))
@@ -328,6 +358,22 @@ namespace Hops
                     errSchema.Errors.Add(serverMessage);
                     parentComponent.HTTPRecord.IOResponseSchema = errSchema;
                 }
+                else if (!responseMessage.IsSuccessStatusCode)
+                {
+                    // Any other non-success status (500/502/503/etc.) — e.g. the server's
+                    // global exception handler returned a JSON error body, or an upstream
+                    // URL fetch failed. Deserializing that body into an IoResponseSchema
+                    // yields null Inputs/Outputs and would NRE in the foreach loops below,
+                    // so surface it as a component error instead.
+                    var detail = ExtractServerErrorMessage(stringResult);
+                    var serverMessage = string.IsNullOrWhiteSpace(detail)
+                        ? $"Could not load the remote definition from {Path}\r\nThe server responded with {(int)responseMessage.StatusCode} ({responseMessage.StatusCode})."
+                        : $"Could not load the remote definition from {Path}\r\n{detail}";
+                    HopsLog.Log.Error(serverMessage);
+                    var errSchema = new IoResponseSchema();
+                    errSchema.Errors.Add(serverMessage);
+                    parentComponent.HTTPRecord.IOResponseSchema = errSchema;
+                }
                 else if (string.IsNullOrEmpty(stringResult))
                 {
                     this.pathType = PathType.InvalidUrl; // Looks like a valid but not related URL
@@ -403,7 +449,9 @@ namespace Hops
                 HopsLog.Log.Debug($"Compute.Geometry found {responseSchema.InputNames?.Count} input{inputSuffix} and {responseSchema.OutputNames?.Count} output{outputSuffix}{fileNameMsg}");
                 inputParams = new Dictionary<string, Tuple<InputParamSchema, IGH_Param>>();
                 outputParams = new Dictionary<string, IGH_Param>();
-                foreach (var input in responseSchema.Inputs)
+                // Defensive: a well-formed /io success response always populates these, but
+                // guard against null so a partial/unexpected body can't NullReference here.
+                foreach (var input in responseSchema.Inputs ?? Enumerable.Empty<InputParamSchema>())
                 {
                     string inputParamName = input.Name;
                     if (inputParamName.StartsWith("RH_IN:"))
@@ -413,7 +461,7 @@ namespace Hops
                     }
                     inputParams[inputParamName] = Tuple.Create(input, ParamFromIoResponseSchema(input));
                 }
-                foreach (var output in responseSchema.Outputs)
+                foreach (var output in responseSchema.Outputs ?? Enumerable.Empty<IoParamSchema>())
                 {
                     string outputParamName = output.Name;
                     if (outputParamName.StartsWith("RH_OUT:"))


### PR DESCRIPTION
## Summary
  When compute.geometry can't load a remote definition (e.g. the source URL is down),
  it returns a 500. The Hops client previously deserialized that error body into an
  empty `IoResponseSchema` and then `NullReferenceException`'d on `responseSchema.Inputs`
  — the component went grey with no message. This makes the failure surface as a clear,
  persistent component error, and cleans up the message. Spans compute.geometry + Hops.

  ### compute.geometry
  - `UrlGuard.GetByteArrayAsync` — on a non-success fetch, throws a clean
    `"The server responded with {code} ({status})."` instead of the generic
    `EnsureSuccessStatusCode` text.
  - `GrasshopperDefinition.ArchiveFromUrl` — unwraps the `AggregateException` that
    `.Result` wraps the failure in, so the clean inner message propagates instead of
    "One or more errors occurred. (…)".

  ### Hops
  - `RemoteDefinition.GetRemoteDescription` — handles *any* non-success status (not
    just 401): surfaces it via `IOResponseSchema.Errors` instead of deserializing into
    a null-`Inputs` schema and NRE-ing. Plus null-guards on the input/output loops.
  - `HopsComponent.SolveInstance` — re-surfaces the error during the solve (Grasshopper
    clears runtime messages at the start of each solve, so the pre-solve message was
    being wiped) and skips solving a definition that never loaded, so it fails fast.
  - `RemoteDefinition.ExtractServerErrorMessage` — pulls just the server's `message`
    field and strips the `XxxException:` type prefix, so the component shows a clean
    two-line message (URL + status) rather than raw JSON + stack trace.

  ## Test plan
  - [x] Hops component pointed at a definition on a down server now shows a red error
        ("Could not load the remote definition from <url>" / "The server responded with
        503 (ServiceUnavailable).") instead of NRE/grey, and fails fast.
  - [x] Happy path (working server + local function-source directory) still loads
        inputs/outputs and solves.
  - [x] compute.geometry and Hops build clean (0 errors).

  Note: the right-click menu staying open during a synchronous request is **not** in
  this PR — it's a UI-thread-blocking symptom deferred to the sync-over-async work.