### PR TITLE
Hops: surface timeouts and network failures, honor HTTPTimeout everyw…

### DIFF
--- a/src/hops/HopsComponent.cs
+++ b/src/hops/HopsComponent.cs
@@ -625,7 +625,9 @@ namespace Hops
             {
                 try
                 {
-                    var getTask = HopsFunctionMgr.HttpClient.GetAsync(row.SourcePath);
+                    using var cts = new System.Threading.CancellationTokenSource(
+                        TimeSpan.FromSeconds(HopsAppSettings.HTTPTimeout));
+                    var getTask = HopsFunctionMgr.HttpClient.GetAsync(row.SourcePath, cts.Token);
                     if (getTask != null)
                     {
                         var responseMessage = getTask.Result;
@@ -1085,16 +1087,24 @@ for value in values:
                 ClearRuntimeMessages();
                 string description = remoteDefinition.GetDescription(out System.Drawing.Bitmap customIcon);
 
-                if (remoteDefinition.IsNotResponingUrl())
+                if (remoteDefinition.IsNotRespondingUrl())
                 {
-                    HopsAddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Unable to connect to server");
+                    var msg = $"Unable to connect to {RemoteDefinitionLocation} within the configured {HopsAppSettings.HTTPTimeout}-second HTTP timeout (raise it in the Hops settings panel if the server is just slow).";
+                    var errSchema = new IoResponseSchema();
+                    errSchema.Errors.Add(msg);
+                    HTTPRecord.IOResponseSchema = errSchema;
+                    HopsAddRuntimeMessage(GH_RuntimeMessageLevel.Error, msg);
                     Grasshopper.Instances.ActiveCanvas?.Invalidate();
                     return;
                 }
 
                 if (remoteDefinition.IsInvalidUrl())
                 {
-                    HopsAddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Path appears valid, but to something that is not Hops related");
+                    var msg = $"The URL {RemoteDefinitionLocation} responded but did not return any Hops definition data. Verify it points to a Hops/Compute endpoint or to a Grasshopper .gh/.ghx file.";
+                    var errSchema = new IoResponseSchema();
+                    errSchema.Errors.Add(msg);
+                    HTTPRecord.IOResponseSchema = errSchema;
+                    HopsAddRuntimeMessage(GH_RuntimeMessageLevel.Error, msg);
                     Grasshopper.Instances.ActiveCanvas?.Invalidate();
                     return;
                 }

--- a/src/hops/HopsFunctionMgr.cs
+++ b/src/hops/HopsFunctionMgr.cs
@@ -161,7 +161,12 @@ namespace Hops
             {
                 if (httpClient == null)
                 {
-                    httpClient = new System.Net.Http.HttpClient();
+                    // Per-request deadlines come from the call site's CancellationTokenSource
+                    // so HopsAppSettings.HTTPTimeout values larger than 100s aren't capped here.
+                    httpClient = new System.Net.Http.HttpClient
+                    {
+                        Timeout = System.Threading.Timeout.InfiniteTimeSpan
+                    };
                 }
                 return httpClient;
             }

--- a/src/hops/RemoteDefinition.cs
+++ b/src/hops/RemoteDefinition.cs
@@ -176,7 +176,7 @@ namespace Hops
             RemoteDefinitionCache.Remove(this);
         }
 
-        public bool IsNotResponingUrl()
+        public bool IsNotRespondingUrl()
         {
             var pathtype = GetPathType();
             return pathtype == PathType.NonresponsiveUrl;
@@ -390,54 +390,80 @@ namespace Hops
             if (responseTask != null)
             {
                 var sw = Stopwatch.StartNew();
-                var responseMessage = responseTask.Result;
-                HopsLog.Log.Debug($"Received response {responseMessage.StatusCode} in {sw.ElapsedMilliseconds}ms");
-                var remoteSolvedData = responseMessage.Content;
-                var stringResult = remoteSolvedData.ReadAsStringAsync().Result;
-                parentComponent.HTTPRecord.IOResponse = stringResult;
+                try
+                {
+                    var responseMessage = responseTask.Result;
+                    HopsLog.Log.Debug($"Received response {responseMessage.StatusCode} in {sw.ElapsedMilliseconds}ms");
+                    var remoteSolvedData = responseMessage.Content;
+                    var stringResult = remoteSolvedData.ReadAsStringAsync().Result;
+                    parentComponent.HTTPRecord.IOResponse = stringResult;
 
-                // Detect 401 BEFORE attempting to parse the body as JSON. The middleware's
-                // response body is plain text ("Api Key was not provided." / "Unauthorized
-                // client."), which would throw JsonReaderException inside the deserializer
-                // below. Surface via IOResponseSchema.Errors so DefineInputsAndOutputs picks
-                // it up and displays a red runtime message on the Hops component.
-                if (responseMessage.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+                    // Detect 401 BEFORE attempting to parse the body as JSON. The middleware's
+                    // response body is plain text ("Api Key was not provided." / "Unauthorized
+                    // client."), which would throw JsonReaderException inside the deserializer
+                    // below. Surface via IOResponseSchema.Errors so DefineInputsAndOutputs picks
+                    // it up and displays a red runtime message on the Hops component.
+                    if (responseMessage.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+                    {
+                        var serverMessage = string.IsNullOrWhiteSpace(stringResult)
+                            ? "Server returned 401 Unauthorized — verify the RHINO_COMPUTE_KEY environment variable on the Hops client matches the server's configured key."
+                            : $"Server returned 401 Unauthorized: {stringResult.Trim()}";
+                        HopsLog.Log.Error(serverMessage);
+                        var errSchema = new IoResponseSchema();
+                        errSchema.Errors.Add(serverMessage);
+                        parentComponent.HTTPRecord.IOResponseSchema = errSchema;
+                    }
+                    else if (!responseMessage.IsSuccessStatusCode)
+                    {
+                        // Any other non-success status (500/502/503/etc.) — e.g. the server's
+                        // global exception handler returned a JSON error body, or an upstream
+                        // URL fetch failed. Deserializing that body into an IoResponseSchema
+                        // yields null Inputs/Outputs and would NRE in the foreach loops below,
+                        // so surface it as a component error instead.
+                        var detail = ExtractServerErrorMessage(stringResult);
+                        var serverMessage = string.IsNullOrWhiteSpace(detail)
+                            ? $"Could not load the remote definition from {Path}\r\nThe server responded with {(int)responseMessage.StatusCode} ({responseMessage.StatusCode})."
+                            : $"Could not load the remote definition from {Path}\r\n{detail}";
+                        HopsLog.Log.Error(serverMessage);
+                        var errSchema = new IoResponseSchema();
+                        errSchema.Errors.Add(serverMessage);
+                        parentComponent.HTTPRecord.IOResponseSchema = errSchema;
+                    }
+                    else if (string.IsNullOrEmpty(stringResult))
+                    {
+                        this.pathType = PathType.InvalidUrl; // Looks like a valid but not related URL
+                        parentComponent.HTTPRecord.IOResponse = "Invalid URL";
+                    }
+                    else
+                    {
+                        responseSchema = JsonConvert.DeserializeObject<IoResponseSchema>(stringResult);
+                        cacheKey = responseSchema.CacheKey;
+                        filename = responseSchema.FileName;
+                        parentComponent.HTTPRecord.IOResponseSchema = responseSchema;
+                    }
+                }
+                catch (Exception ex)
                 {
-                    var serverMessage = string.IsNullOrWhiteSpace(stringResult)
-                        ? "Server returned 401 Unauthorized — verify the RHINO_COMPUTE_KEY environment variable on the Hops client matches the server's configured key."
-                        : $"Server returned 401 Unauthorized: {stringResult.Trim()}";
+                    // Surface cancellation (HTTPTimeout exceeded) or network failure as a clear
+                    // runtime message on the component instead of bubbling up to Grasshopper
+                    // where the exception is swallowed silently. .Result wraps the underlying
+                    // failure in AggregateException; unwrap one level so the message is clean.
+                    var inner = ex is AggregateException ae && ae.InnerException != null
+                        ? ae.InnerException
+                        : ex;
+                    string serverMessage;
+                    if (inner is OperationCanceledException)
+                    {
+                        serverMessage = $"Could not load the remote definition from {Path}\r\nRequest timed out after {sw.Elapsed.TotalSeconds:0.0}s (configured timeout: {HopsAppSettings.HTTPTimeout}s — raise it in the Hops settings panel if the server is just slow).";
+                    }
+                    else
+                    {
+                        serverMessage = $"Could not load the remote definition from {Path}\r\n{inner.Message}";
+                    }
                     HopsLog.Log.Error(serverMessage);
                     var errSchema = new IoResponseSchema();
                     errSchema.Errors.Add(serverMessage);
                     parentComponent.HTTPRecord.IOResponseSchema = errSchema;
-                }
-                else if (!responseMessage.IsSuccessStatusCode)
-                {
-                    // Any other non-success status (500/502/503/etc.) — e.g. the server's
-                    // global exception handler returned a JSON error body, or an upstream
-                    // URL fetch failed. Deserializing that body into an IoResponseSchema
-                    // yields null Inputs/Outputs and would NRE in the foreach loops below,
-                    // so surface it as a component error instead.
-                    var detail = ExtractServerErrorMessage(stringResult);
-                    var serverMessage = string.IsNullOrWhiteSpace(detail)
-                        ? $"Could not load the remote definition from {Path}\r\nThe server responded with {(int)responseMessage.StatusCode} ({responseMessage.StatusCode})."
-                        : $"Could not load the remote definition from {Path}\r\n{detail}";
-                    HopsLog.Log.Error(serverMessage);
-                    var errSchema = new IoResponseSchema();
-                    errSchema.Errors.Add(serverMessage);
-                    parentComponent.HTTPRecord.IOResponseSchema = errSchema;
-                }
-                else if (string.IsNullOrEmpty(stringResult))
-                {
-                    this.pathType = PathType.InvalidUrl; // Looks like a valid but not related URL
-                    parentComponent.HTTPRecord.IOResponse = "Invalid URL";
-                }
-                else
-                {
-                    responseSchema = JsonConvert.DeserializeObject<IoResponseSchema>(stringResult);
-                    cacheKey = responseSchema.CacheKey;
-                    filename = responseSchema.FileName;
-                    parentComponent.HTTPRecord.IOResponseSchema = responseSchema;
                 }
             }
 


### PR DESCRIPTION
…here

## Summary
  Three related fixes that make the user-configurable `HopsAppSettings.HTTPTimeout` setting actually work end-to-end, and surface failures clearly on the component instead of vanishing or rendering a
  blank/grey component:

  - **`HopsFunctionMgr.HttpClient` had no explicit timeout.** The right-click → Function Sources menu fetch (`HopsComponent.GenerateFunctionPathMenu`) used the shared `HttpClient` with no `Timeout`
  set, falling back to .NET's 100 s default. A slow/dead source froze Rhino's UI for the full 100 s while building the menu. Now matches the two-layer pattern used by `RemoteDefinition.HttpClient`: the
   client is constructed with `Timeout = InfiniteTimeSpan` and the call site wraps the request in a per-call `CancellationTokenSource` initialized from `HopsAppSettings.HTTPTimeout`. Values larger than
   100 s are no longer silently capped.

  - **`RemoteDefinition.GetRemoteDescription` silently swallowed timeout / network failures on the POST path.** The existing CTS-based timeout was honored at the HTTP layer — when it fired,
  `responseTask.Result` threw `AggregateException(TaskCanceledException)`. But the call wasn't wrapped in a try/catch, so the exception bubbled up to Grasshopper, which swallowed it without rendering
  anything. Fix: wrap the response-handling block in a try/catch that unwraps the inner exception and distinguishes:
    - `OperationCanceledException` → `Could not load the remote definition from {Path}\r\nRequest timed out after {elapsed}s (configured timeout: {HopsAppSettings.HTTPTimeout}s — raise it in the Hops
  settings panel if the server is just slow).` Elapsed time is measured by a `Stopwatch` hoisted out of the try so the catch can read it.
    - Any other exception → `Could not load the remote definition from {Path}\r\n{innerException.Message}`
    - Both surface via `HTTPRecord.IOResponseSchema.Errors` and log via `HopsLog.Log.Error`.

  - **`IsNotRespondingUrl` / `IsInvalidUrl` paths in `DefineInputsAndOutputs` weren't surviving Grasshopper's solve-start runtime-message clear.** Both branches added their message directly via
  `HopsAddRuntimeMessage` but never set `HTTPRecord.IOResponseSchema.Errors`, so the `SolveInstance` re-surface block from PR #905 couldn't pick them up — the message vanished as soon as the next solve
   started. Both branches now also populate `HTTPRecord.IOResponseSchema.Errors` so the re-surface mechanism handles them. Bonus: messages are now more informative —
    - `IsNotRespondingUrl`: `Unable to connect to {Path} within the configured {HopsAppSettings.HTTPTimeout}-second HTTP timeout (raise it in the Hops settings panel if the server is just slow).`
    - `IsInvalidUrl`: `The URL {Path} responded but did not return any Hops definition data. Verify it points to a Hops/Compute endpoint or to a Grasshopper .gh/.ghx file.`

  - **Typo:** renamed `IsNotResponingUrl` → `IsNotRespondingUrl` (method definition in `RemoteDefinition.cs` and the one call site in `HopsComponent.cs`).

  ## Test plan
  - [x] Build succeeds (0 errors, 0 warnings).
  - [x] Function-source menu timeout: with `HopsAppSettings.HTTPTimeout` set to a low value, the right-click menu against a dead source falls through promptly instead of freezing for 100 s.
  - [x] Definition load timeout: setting `HopsAppSettings.HTTPTimeout=15s` and pointing at a dead URL shows a red `Unable to connect to <url> within the configured 15-second HTTP timeout ...` error on
  the component, and the message survives the next solve cycle.
  - [x] `IsInvalidUrl` path: verified via a minimal fake compute server that returns 200 OK with empty body — the new "responded but did not return any Hops definition data" message renders correctly.
  - [x] Existing happy path: loading a definition from a healthy URL still works unchanged.