### PR TITLE
Hops: rename HTTP/IO acronyms to PascalCase, consolidate HttpRecord e…

### DIFF
--- a/src/compute.geometry/IO/Schema.cs
+++ b/src/compute.geometry/IO/Schema.cs
@@ -91,18 +91,18 @@ namespace Resthopper.IO
         public List<string> Errors { get; set; } = new List<string>();
     }
 
-    public class HTTPRecord
+    public class HttpRecord
     {
-        public HTTPRecord()
+        public HttpRecord()
         {
 
         }
-        public string IORequest { get; set; }
-        public string IOResponse { get; set; }
+        public string IoRequest { get; set; }
+        public string IoResponse { get; set; }
         public string SolveRequest { get; set; }
         public string SolveResponse { get; set; }
         public Schema Schema { get; set; }
-        public IoResponseSchema IOResponseSchema { get; set; }
+        public IoResponseSchema IoResponseSchema { get; set; }
     }
 
     public class ResthopperObject : IEquatable<ResthopperObject>

--- a/src/hops/HopsAppSettings.cs
+++ b/src/hops/HopsAppSettings.cs
@@ -271,7 +271,7 @@ namespace Hops
         }
 
         static int httpTimeout = 0;
-        public static int HTTPTimeout
+        public static int HttpTimeout
         {
             get
             {

--- a/src/hops/HopsAppSettingsUserControl.cs
+++ b/src/hops/HopsAppSettingsUserControl.cs
@@ -15,7 +15,7 @@ namespace Hops
             _serversTextBox.TextChanged += ServersTextboxChanged;
             _apiKeyTextbox.Text = HopsAppSettings.APIKey;
             _apiKeyTextbox.TextChanged += APIKeyTextboxChanged;
-            _httpTimeoutTextbox.Text = HopsAppSettings.HTTPTimeout.ToString();
+            _httpTimeoutTextbox.Text = HopsAppSettings.HttpTimeout.ToString();
             _httpTimeoutTextbox.KeyPress += (s, e) =>
             {
                 e.Handled = !char.IsDigit(e.KeyChar) && !char.IsControl(e.KeyChar);
@@ -24,7 +24,7 @@ namespace Hops
             {
                 if (int.TryParse(_httpTimeoutTextbox.Text, out int result) && result > 0)
                 {
-                    HopsAppSettings.HTTPTimeout = result;
+                    HopsAppSettings.HttpTimeout = result;
                 }
             };
             _maxConcurrentRequestsTextbox.Text = HopsAppSettings.MaxConcurrentRequests.ToString();

--- a/src/hops/HopsComponent.cs
+++ b/src/hops/HopsComponent.cs
@@ -151,13 +151,13 @@ namespace Hops
 
         public int SolveSerialNumber => solveSerialNumber;
 
-        HTTPRecord httpRecord;
-        public HTTPRecord HTTPRecord
+        HttpRecord httpRecord;
+        public HttpRecord HttpRecord
         {
             get
             {
                 if (httpRecord == null)
-                    httpRecord = new HTTPRecord();
+                    httpRecord = new HttpRecord();
                 return httpRecord; 
             }
         }
@@ -206,9 +206,9 @@ namespace Hops
             // location is set, but Grasshopper clears runtime messages at the start of every
             // solve — so re-surface it here, during SolveInstance, where it survives to render.
             // Skip solving a definition that never loaded.
-            if (HTTPRecord.IOResponseSchema != null && HTTPRecord.IOResponseSchema.Errors.Count > 0)
+            if (HttpRecord.IoResponseSchema != null && HttpRecord.IoResponseSchema.Errors.Count > 0)
             {
-                foreach (var error in HTTPRecord.IOResponseSchema.Errors)
+                foreach (var error in HttpRecord.IoResponseSchema.Errors)
                     HopsAddRuntimeMessage(GH_RuntimeMessageLevel.Error, error);
                 return;
             }
@@ -586,10 +586,10 @@ namespace Hops
             restAPITsi.Enabled = remoteDefinition != null;
             exportTsi.DropDownItems.Add(restAPITsi);
 
-            tsi = new ToolStripMenuItem("Last IO request...", null, (s, e) => { ExportLastIORequest(); });
+            tsi = new ToolStripMenuItem("Last IO request...", null, (s, e) => { ExportLastIoRequest(); });
             restAPITsi.DropDownItems.Add(tsi);
 
-            tsi = new ToolStripMenuItem("Last IO response...", null, (s, e) => { ExportLastIOResponse(); });
+            tsi = new ToolStripMenuItem("Last IO response...", null, (s, e) => { ExportLastIoResponse(); });
             restAPITsi.DropDownItems.Add(tsi);
 
             tsi = new ToolStripMenuItem("Last Solve request...", null, (s, e) => { ExportLastSolveRequest(); });
@@ -626,7 +626,7 @@ namespace Hops
                 try
                 {
                     using var cts = new System.Threading.CancellationTokenSource(
-                        TimeSpan.FromSeconds(HopsAppSettings.HTTPTimeout));
+                        TimeSpan.FromSeconds(HopsAppSettings.HttpTimeout));
                     var getTask = HopsFunctionMgr.HttpClient.GetAsync(row.SourcePath, cts.Token);
                     if (getTask != null)
                     {
@@ -858,9 +858,9 @@ for value in values:
             }
         }
 
-        void ExportLastIORequest()
+        void ExportLastIoRequest()
         {
-            if (String.IsNullOrEmpty(HTTPRecord.IORequest))
+            if (String.IsNullOrEmpty(HttpRecord.IoRequest))
             {
                 Eto.Forms.MessageBox.Show("No IO request has been made. Run this component at least once", Eto.Forms.MessageBoxType.Error);
                 return;
@@ -869,13 +869,13 @@ for value in values:
             dlg.Filters.Add(new Eto.Forms.FileFilter("JSON file", ".json"));
             if (dlg.ShowDialog(Grasshopper.Instances.EtoDocumentEditor) == Eto.Forms.DialogResult.Ok)
             {
-                System.IO.File.WriteAllText(dlg.FileName, HTTPRecord.IORequest);
+                System.IO.File.WriteAllText(dlg.FileName, HttpRecord.IoRequest);
             }
         }
 
-        void ExportLastIOResponse()
+        void ExportLastIoResponse()
         {
-            if (String.IsNullOrEmpty(HTTPRecord.IOResponse))
+            if (String.IsNullOrEmpty(HttpRecord.IoResponse))
             {
                 Eto.Forms.MessageBox.Show("No IO response has been received. Run this component at least once", Eto.Forms.MessageBoxType.Error);
                 return;
@@ -884,13 +884,13 @@ for value in values:
             dlg.Filters.Add(new Eto.Forms.FileFilter("JSON file", ".json"));
             if (dlg.ShowDialog(Grasshopper.Instances.EtoDocumentEditor) == Eto.Forms.DialogResult.Ok)
             {
-                System.IO.File.WriteAllText(dlg.FileName, HTTPRecord.IOResponse);
+                System.IO.File.WriteAllText(dlg.FileName, HttpRecord.IoResponse);
             }
         }
 
         void ExportLastSolveRequest()
         {
-            if (String.IsNullOrEmpty(HTTPRecord.SolveRequest))
+            if (String.IsNullOrEmpty(HttpRecord.SolveRequest))
             {
                 Eto.Forms.MessageBox.Show("No solve request has been made. Run this component at least once", Eto.Forms.MessageBoxType.Error);
                 return;
@@ -899,13 +899,13 @@ for value in values:
             dlg.Filters.Add(new Eto.Forms.FileFilter("JSON file", ".json"));
             if (dlg.ShowDialog(Grasshopper.Instances.EtoDocumentEditor) == Eto.Forms.DialogResult.Ok)
             {
-                System.IO.File.WriteAllText(dlg.FileName, HTTPRecord.SolveRequest);
+                System.IO.File.WriteAllText(dlg.FileName, HttpRecord.SolveRequest);
             }
         }
 
         void ExportLastSolveResponse()
         {
-            if (String.IsNullOrEmpty(HTTPRecord.SolveResponse))
+            if (String.IsNullOrEmpty(HttpRecord.SolveResponse))
             {
                 Eto.Forms.MessageBox.Show("No solve response has been received. Run this component at least once", Eto.Forms.MessageBoxType.Error);
                 return;
@@ -914,7 +914,7 @@ for value in values:
             dlg.Filters.Add(new Eto.Forms.FileFilter("JSON file", ".json"));
             if (dlg.ShowDialog(Grasshopper.Instances.EtoDocumentEditor) == Eto.Forms.DialogResult.Ok)
             {
-                System.IO.File.WriteAllText(dlg.FileName, HTTPRecord.SolveResponse);
+                System.IO.File.WriteAllText(dlg.FileName, HttpRecord.SolveResponse);
             }
         }
 
@@ -1089,10 +1089,10 @@ for value in values:
 
                 if (remoteDefinition.IsNotRespondingUrl())
                 {
-                    var msg = $"Unable to connect to {RemoteDefinitionLocation} within the configured {HopsAppSettings.HTTPTimeout}-second HTTP timeout (raise it in the Hops settings panel if the server is just slow).";
+                    var msg = $"Unable to connect to {RemoteDefinitionLocation} within the configured {HopsAppSettings.HttpTimeout}-second HTTP timeout (raise it in the Hops settings panel if the server is just slow).";
                     var errSchema = new IoResponseSchema();
                     errSchema.Errors.Add(msg);
-                    HTTPRecord.IOResponseSchema = errSchema;
+                    HttpRecord.IoResponseSchema = errSchema;
                     HopsAddRuntimeMessage(GH_RuntimeMessageLevel.Error, msg);
                     Grasshopper.Instances.ActiveCanvas?.Invalidate();
                     return;
@@ -1103,23 +1103,23 @@ for value in values:
                     var msg = $"The URL {RemoteDefinitionLocation} responded but did not return any Hops definition data. Verify it points to a Hops/Compute endpoint or to a Grasshopper .gh/.ghx file.";
                     var errSchema = new IoResponseSchema();
                     errSchema.Errors.Add(msg);
-                    HTTPRecord.IOResponseSchema = errSchema;
+                    HttpRecord.IoResponseSchema = errSchema;
                     HopsAddRuntimeMessage(GH_RuntimeMessageLevel.Error, msg);
                     Grasshopper.Instances.ActiveCanvas?.Invalidate();
                     return;
                 }
-                if(HTTPRecord.IOResponseSchema != null && HTTPRecord.IOResponseSchema.Errors.Count > 0)
+                if(HttpRecord.IoResponseSchema != null && HttpRecord.IoResponseSchema.Errors.Count > 0)
                 {
-                    foreach(var error in HTTPRecord.IOResponseSchema.Errors)
+                    foreach(var error in HttpRecord.IoResponseSchema.Errors)
                     {
                         HopsAddRuntimeMessage(GH_RuntimeMessageLevel.Error, error);
                         Grasshopper.Instances.ActiveCanvas?.Invalidate();
                         return;
                     }
                 }
-                if(HTTPRecord.IOResponseSchema != null && HTTPRecord.IOResponseSchema.Warnings.Count > 0)
+                if(HttpRecord.IoResponseSchema != null && HttpRecord.IoResponseSchema.Warnings.Count > 0)
                 {
-                    foreach (var warning in HTTPRecord.IOResponseSchema.Warnings)
+                    foreach (var warning in HttpRecord.IoResponseSchema.Warnings)
                     {
                         HopsAddRuntimeMessage(GH_RuntimeMessageLevel.Warning, warning);
                     }

--- a/src/hops/HopsFunctionMgr.cs
+++ b/src/hops/HopsFunctionMgr.cs
@@ -162,7 +162,7 @@ namespace Hops
                 if (httpClient == null)
                 {
                     // Per-request deadlines come from the call site's CancellationTokenSource
-                    // so HopsAppSettings.HTTPTimeout values larger than 100s aren't capped here.
+                    // so HopsAppSettings.HttpTimeout values larger than 100s aren't capped here.
                     httpClient = new System.Net.Http.HttpClient
                     {
                         Timeout = System.Threading.Timeout.InfiniteTimeSpan

--- a/src/hops/RemoteDefinition.cs
+++ b/src/hops/RemoteDefinition.cs
@@ -155,6 +155,22 @@ namespace Hops
             return System.IO.File.ReadAllBytes(path);
         }
 
+        // Builds the debug envelope captured into HttpRecord.{IoRequest,SolveRequest}.
+        // Using a JObject (Newtonsoft is already a dependency) instead of hand-rolled string
+        // concat gives a consistent shape across all sites and proper JSON escaping for free.
+        // contentJson is embedded as a parsed JToken (not a string) so it nests cleanly.
+        static string BuildRequestEnvelope(string url, string method, string contentJson = null)
+        {
+            var obj = new Newtonsoft.Json.Linq.JObject
+            {
+                ["URL"] = url,
+                ["Method"] = method,
+            };
+            if (!string.IsNullOrEmpty(contentJson))
+                obj["Content"] = Newtonsoft.Json.Linq.JToken.Parse(contentJson);
+            return obj.ToString();
+        }
+
         public void InternalizeDefinition(string path)
         {
             internalizedDefinition = ReadLocalFileWithSizeCap(path);
@@ -336,7 +352,7 @@ namespace Hops
                                 HopsLog.Log.Error(ex.Message);
                                 var errSchema = new IoResponseSchema();
                                 errSchema.Errors.Add(ex.Message);
-                                parentComponent.HTTPRecord.IOResponseSchema = errSchema;
+                                parentComponent.HttpRecord.IoResponseSchema = errSchema;
                                 return;
                             }
                         }
@@ -356,12 +372,7 @@ namespace Hops
                 schema.ModelUnits = GetDocumentUnits();
                 schema.FileName = filename;
                 string inputJson = JsonConvert.SerializeObject(schema);
-                string requestContent = "{";
-                requestContent += "\"URL\": \"" + postUrl + "\"," + Environment.NewLine;
-                requestContent += "\"Method\": \"POST" + "\"," + Environment.NewLine;
-                requestContent += "\"Content\": " + inputJson  + Environment.NewLine;
-                requestContent += "}";
-                parentComponent.HTTPRecord.IORequest = requestContent;
+                parentComponent.HttpRecord.IoRequest = BuildRequestEnvelope(postUrl, "POST", inputJson);
                 var content = new System.Net.Http.StringContent(inputJson, Encoding.UTF8, "application/json");
                 var request = new System.Net.Http.HttpRequestMessage(System.Net.Http.HttpMethod.Post, postUrl) { Content = content };
                 AddApiKeyHeader(request);
@@ -371,18 +382,14 @@ namespace Hops
                     fileNameMsg = $" with {filename}";
                 HopsLog.Log.Debug($"Sending POST request to {postUrl}{fileNameMsg}");
                 responseTask = HttpClient.SendAsync(request, cts.Token);
-                parentComponent.HTTPRecord.Schema = schema;
+                parentComponent.HttpRecord.Schema = schema;
                 contentToDispose = content;
                 requestToDispose = request;
                 ctsToDispose = cts;
             }
             else
             {
-                string requestContent = "{";
-                requestContent += "\"URL\": \"" + address + "\"," + Environment.NewLine;
-                requestContent += "\"Method\": \"GET" + "\"" + Environment.NewLine;
-                requestContent += "}";
-                parentComponent.HTTPRecord.IORequest = requestContent;
+                parentComponent.HttpRecord.IoRequest = BuildRequestEnvelope(address, "GET");
                 var cts = CreateTimeoutCts();
                 responseTask = HttpClient.GetAsync(address, cts.Token);
                 ctsToDispose = cts;
@@ -396,12 +403,12 @@ namespace Hops
                     HopsLog.Log.Debug($"Received response {responseMessage.StatusCode} in {sw.ElapsedMilliseconds}ms");
                     var remoteSolvedData = responseMessage.Content;
                     var stringResult = remoteSolvedData.ReadAsStringAsync().Result;
-                    parentComponent.HTTPRecord.IOResponse = stringResult;
+                    parentComponent.HttpRecord.IoResponse = stringResult;
 
                     // Detect 401 BEFORE attempting to parse the body as JSON. The middleware's
                     // response body is plain text ("Api Key was not provided." / "Unauthorized
                     // client."), which would throw JsonReaderException inside the deserializer
-                    // below. Surface via IOResponseSchema.Errors so DefineInputsAndOutputs picks
+                    // below. Surface via IoResponseSchema.Errors so DefineInputsAndOutputs picks
                     // it up and displays a red runtime message on the Hops component.
                     if (responseMessage.StatusCode == System.Net.HttpStatusCode.Unauthorized)
                     {
@@ -411,7 +418,7 @@ namespace Hops
                         HopsLog.Log.Error(serverMessage);
                         var errSchema = new IoResponseSchema();
                         errSchema.Errors.Add(serverMessage);
-                        parentComponent.HTTPRecord.IOResponseSchema = errSchema;
+                        parentComponent.HttpRecord.IoResponseSchema = errSchema;
                     }
                     else if (!responseMessage.IsSuccessStatusCode)
                     {
@@ -427,24 +434,24 @@ namespace Hops
                         HopsLog.Log.Error(serverMessage);
                         var errSchema = new IoResponseSchema();
                         errSchema.Errors.Add(serverMessage);
-                        parentComponent.HTTPRecord.IOResponseSchema = errSchema;
+                        parentComponent.HttpRecord.IoResponseSchema = errSchema;
                     }
                     else if (string.IsNullOrEmpty(stringResult))
                     {
                         this.pathType = PathType.InvalidUrl; // Looks like a valid but not related URL
-                        parentComponent.HTTPRecord.IOResponse = "Invalid URL";
+                        parentComponent.HttpRecord.IoResponse = "Invalid URL";
                     }
                     else
                     {
                         responseSchema = JsonConvert.DeserializeObject<IoResponseSchema>(stringResult);
                         cacheKey = responseSchema.CacheKey;
                         filename = responseSchema.FileName;
-                        parentComponent.HTTPRecord.IOResponseSchema = responseSchema;
+                        parentComponent.HttpRecord.IoResponseSchema = responseSchema;
                     }
                 }
                 catch (Exception ex)
                 {
-                    // Surface cancellation (HTTPTimeout exceeded) or network failure as a clear
+                    // Surface cancellation (HttpTimeout exceeded) or network failure as a clear
                     // runtime message on the component instead of bubbling up to Grasshopper
                     // where the exception is swallowed silently. .Result wraps the underlying
                     // failure in AggregateException; unwrap one level so the message is clean.
@@ -454,7 +461,7 @@ namespace Hops
                     string serverMessage;
                     if (inner is OperationCanceledException)
                     {
-                        serverMessage = $"Could not load the remote definition from {Path}\r\nRequest timed out after {sw.Elapsed.TotalSeconds:0.0}s (configured timeout: {HopsAppSettings.HTTPTimeout}s — raise it in the Hops settings panel if the server is just slow).";
+                        serverMessage = $"Could not load the remote definition from {Path}\r\nRequest timed out after {sw.Elapsed.TotalSeconds:0.0}s (configured timeout: {HopsAppSettings.HttpTimeout}s — raise it in the Hops settings panel if the server is just slow).";
                     }
                     else
                     {
@@ -463,7 +470,7 @@ namespace Hops
                     HopsLog.Log.Error(serverMessage);
                     var errSchema = new IoResponseSchema();
                     errSchema.Errors.Add(serverMessage);
-                    parentComponent.HTTPRecord.IOResponseSchema = errSchema;
+                    parentComponent.HttpRecord.IoResponseSchema = errSchema;
                 }
             }
 
@@ -550,7 +557,7 @@ namespace Hops
                     }
                     outputParams[outputParamName] = ParamFromIoResponseSchema(output);
                 }
-                parentComponent.HTTPRecord.IOResponseSchema = responseSchema;
+                parentComponent.HttpRecord.IoResponseSchema = responseSchema;
             }
         }
 
@@ -620,7 +627,7 @@ namespace Hops
                 {
                     // One shared HttpClient for all requests (avoids per-request socket allocation).
                     // Timeout is intentionally infinite — per-request CancellationTokenSource
-                    // controls actual deadlines so HopsAppSettings.HTTPTimeout values larger than
+                    // controls actual deadlines so HopsAppSettings.HttpTimeout values larger than
                     // 100s aren't capped by HttpClient's default.
                     httpClient = new System.Net.Http.HttpClient
                     {
@@ -631,11 +638,11 @@ namespace Hops
             }
         }
 
-        // Per-request timeout via CancellationTokenSource. Uses HopsAppSettings.HTTPTimeout
+        // Per-request timeout via CancellationTokenSource. Uses HopsAppSettings.HttpTimeout
         // if configured, otherwise falls back to 100 seconds (HttpClient's historical default).
         static System.Threading.CancellationTokenSource CreateTimeoutCts()
         {
-            int seconds = HopsAppSettings.HTTPTimeout > 0 ? HopsAppSettings.HTTPTimeout : 100;
+            int seconds = HopsAppSettings.HttpTimeout > 0 ? HopsAppSettings.HttpTimeout : 100;
             return new System.Threading.CancellationTokenSource(TimeSpan.FromSeconds(seconds));
         }
 
@@ -686,11 +693,8 @@ namespace Hops
                     return cachedResults;
                 }
             }
-            string requestContent = "{";
-            requestContent += "\"URL\": \"" + solveUrl + "\"," + Environment.NewLine;
-            requestContent += "\"content\": " + inputJson + Environment.NewLine;
-            requestContent += "}";
-            parentComponent.HTTPRecord.SolveRequest = requestContent;
+            string requestContent = BuildRequestEnvelope(solveUrl, "POST", inputJson);
+            parentComponent.HttpRecord.SolveRequest = requestContent;
             using (var content = new System.Net.Http.StringContent(inputJson, Encoding.UTF8, "application/json"))
             using (var request = new System.Net.Http.HttpRequestMessage(System.Net.Http.HttpMethod.Post, solveUrl) { Content = content })
             using (var cts = CreateTimeoutCts())
@@ -706,7 +710,7 @@ namespace Hops
                 HopsLog.Log.Debug($"Received response {responseMessage.StatusCode} in {sw.ElapsedMilliseconds}ms");
                 var remoteSolvedData = responseMessage.Content;
                 var stringResult = remoteSolvedData.ReadAsStringAsync().Result;
-                parentComponent.HTTPRecord.SolveResponse = stringResult;
+                parentComponent.HttpRecord.SolveResponse = stringResult;
                 Schema schema = SafeSchemaDeserialize(stringResult);
                 if (schema == null && responseMessage.StatusCode == System.Net.HttpStatusCode.InternalServerError)
                 {
@@ -724,18 +728,15 @@ namespace Hops
                             var badSchema = new Schema();
                             HopsLog.Log.Error(ex.Message);
                             badSchema.Errors.Add(ex.Message);
-                            parentComponent.HTTPRecord.Schema = badSchema;
+                            parentComponent.HttpRecord.Schema = badSchema;
                             return badSchema;
                         }
                         string base64 = Convert.ToBase64String(bytes);
                         inputSchema.Algo = base64;
                         inputSchema.FileName = System.IO.Path.GetFileName(Path);
                         inputJson = JsonConvert.SerializeObject(inputSchema);
-                        requestContent = "{";
-                        requestContent += "\"URL\": \"" + solveUrl + "\"," + Environment.NewLine;
-                        requestContent += "\"content\":" + inputJson + Environment.NewLine;
-                        requestContent += "}";
-                        parentComponent.HTTPRecord.SolveRequest = requestContent;
+                        requestContent = BuildRequestEnvelope(solveUrl, "POST", inputJson);
+                        parentComponent.HttpRecord.SolveRequest = requestContent;
                         using var content2 = new System.Net.Http.StringContent(inputJson, Encoding.UTF8, "application/json");
                         using var request2 = new System.Net.Http.HttpRequestMessage(System.Net.Http.HttpMethod.Post, solveUrl) { Content = content2 };
                         using var cts2 = CreateTimeoutCts();
@@ -750,7 +751,7 @@ namespace Hops
                         HopsLog.Log.Debug($"Received response {responseMessage.StatusCode} in {sw2.ElapsedMilliseconds}ms");
                         remoteSolvedData = responseMessage.Content;
                         stringResult = remoteSolvedData.ReadAsStringAsync().Result;
-                        parentComponent.HTTPRecord.SolveResponse = stringResult;
+                        parentComponent.HttpRecord.SolveResponse = stringResult;
                         schema = SafeSchemaDeserialize(stringResult);
                         if (schema == null && responseMessage.StatusCode == System.Net.HttpStatusCode.InternalServerError)
                         {
@@ -759,7 +760,7 @@ namespace Hops
                             HopsLog.Log.Error(errorMsg);
                             badSchema.Errors.Add(errorMsg);
                             badSchema.Warnings.Add(autoUploadMessage);
-                            parentComponent.HTTPRecord.Schema = badSchema;
+                            parentComponent.HttpRecord.Schema = badSchema;
                             return badSchema;
                         }
                         if (schema != null)
@@ -773,7 +774,7 @@ namespace Hops
                             var errorMsg = $"Unable to find file: {Path}";
                             HopsLog.Log.Error(errorMsg);
                             badSchema.Errors.Add(errorMsg);
-                            parentComponent.HTTPRecord.Schema = badSchema;
+                            parentComponent.HttpRecord.Schema = badSchema;
                             return badSchema;
                         }
                     }
@@ -785,7 +786,7 @@ namespace Hops
                     var errorMsg = $"Request timeout: {Path}";
                     HopsLog.Log.Error(errorMsg);
                     badSchema.Errors.Add(errorMsg);
-                    parentComponent.HTTPRecord.Schema = badSchema;
+                    parentComponent.HttpRecord.Schema = badSchema;
                     return badSchema;
                 }
 
@@ -804,7 +805,7 @@ namespace Hops
                         : $"Server returned 401 Unauthorized: {stringResult.Trim()}";
                     HopsLog.Log.Error(serverMessage);
                     badSchema.Errors.Add(serverMessage);
-                    parentComponent.HTTPRecord.Schema = badSchema;
+                    parentComponent.HttpRecord.Schema = badSchema;
                     return badSchema;
                 }
 
@@ -1591,7 +1592,7 @@ namespace Hops
                 var pointer = new Uri(Path).AbsolutePath;
                 schema.Pointer = pointer.Substring(1);
             }
-            parentComponent.HTTPRecord.Schema = schema;
+            parentComponent.HttpRecord.Schema = schema;
             return schema;
         }
     }


### PR DESCRIPTION
…nvelope builder

## Summary
  Two related cleanups in the Hops debug/diagnostic surface:

  ### 1. Consolidate HttpRecord envelope builders into a helper
  Replaced four hand-rolled string-concat JSON builders in `RemoteDefinition.cs` (the debug envelopes captured into `HttpRecord.IoRequest` / `HttpRecord.SolveRequest` for the right-click "Export Last
  ..." menu items) with a single private `BuildRequestEnvelope(url, method, contentJson)` helper backed by `JObject`. Fixes several latent issues at the same time:
  - Casing inconsistency between IO sites (`"Content"` capital) and Solve sites (`"content"` lowercase) — now all `"Content"`.
  - Solve sites omitted the `"Method"` field entirely — now populated.
  - An odd `"\"POST" + "\""` string split (no-op artifact).
  - Hand-rolled JSON would have escaped poorly if a URL contained a quote — `JObject` handles it.
  - No behavior change for the actual HTTP request; only the in-memory debug envelope.

  ### 2. Rename HTTP/IO acronyms to .NET PascalCase convention
  .NET style for 3+ letter acronyms is `Http`, not `HTTP` (`HttpClient`, `HttpRequest`, etc.). Renamed:
  - `HTTPRecord` → `HttpRecord` (class in `compute.geometry/IO/Schema.cs`, property on `HopsComponent`, ~25 use sites)
  - `HTTPTimeout` → `HttpTimeout` (public property on `HopsAppSettings`, ~6 use sites). The persisted Grasshopper-settings storage key remains the string `"Hops:HttpTimeout"` (already PascalCase) —
  user settings carry over.
  - `IORequest` → `IoRequest`, `IOResponse` → `IoResponse`, `IOResponseSchema` → `IoResponseSchema` (properties on `HttpRecord`). The `IoResponseSchema` *type* already had this name — the property was
  the outlier.

  `HttpRecord` is an in-process debug container (never serialized to JSON, never sent over the wire). `Schema.cs` is consumed by both Hops and compute.geometry as a linked source file (not a binary
  assembly), so no external consumer's binary contract is affected. The exported file contents from the right-click "Export Last ..." menu items are the raw string values of `IoRequest` / `IoResponse`
  (just JSON content) — the C# property renames don't affect file format.

  ### Trade-offs
  - Exported debug files now have `"Content"` (capital) and an added `"Method"` field on Solve exports, where they previously had `"content"` lowercase. Anyone diffing old exports against new will see
  the change; nothing automated should be parsing these debug files.

  ## Test plan
  - [x] Build succeeds for both Hops and compute.geometry (0 errors).
  - [x] Run a normal Hops solve against a local-file definition; right-click → Export Last IO Request → exported JSON has `URL` / `Method` / `Content` fields.
  - [x] Same for Export Last Solve Request — now also has `Method: "POST"` and `Content` (capital).
  - [x] Open Grasshopper Settings → Solver → Hops dialog and confirm the HTTP timeout textbox still shows the persisted value (rename of the C# property didn't touch the storage key).
  - [x] Change HTTP timeout from the dialog and verify the new value is honored on the next solve.