### PR TITLE
rhino.compute: graceful child shutdown + fix interleaved console output

### DIFF
--- a/src/compute.geometry/FixedEndpoints.cs
+++ b/src/compute.geometry/FixedEndpoints.cs
@@ -5,6 +5,8 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using System.Linq;
 using Newtonsoft.Json.Linq;
 using Rhino.PlugIns;
@@ -21,6 +23,7 @@ namespace compute.geometry
             app.MapGet("plugins/rhino/installed", GetInstalledPluginsRhino);
             app.MapGet("plugins/gh/installed", GetInstalledPluginsGrasshopper);
             app.MapPost("cache/purge", PurgeCache);
+            app.MapPost("shutdown", ShutdownChild);
         }
 
         static void HomePage(HttpContext context)
@@ -77,6 +80,28 @@ namespace compute.geometry
             Serilog.Log.Information("Cache purge requested: removed {Count} solve-results / URL-data entries", removed);
             ctx.Response.ContentType = "application/json";
             await ctx.Response.WriteAsJsonAsync(new { purged = removed });
+        }
+
+        // POST /shutdown — graceful self-shutdown for this compute.geometry child. Auth-gated
+        // by ApiKeyMiddleware (POST). Used by rhino.compute when its ApplicationStopping
+        // lifecycle hook fires (clean parent exit), and by the planned /shutdown-children +
+        // /recycle-children endpoints in rhino.compute for manual control. The existing
+        // 5-second self-monitoring TimerTask in Shutdown.cs remains as the fallback for
+        // hard-crash scenarios where the parent dies without running its lifecycle hooks.
+        //
+        // Responds 202 Accepted immediately and triggers app.StopAsync() on a background
+        // task so the response can flush before the host stops.
+        static Task ShutdownChild(HttpContext ctx)
+        {
+            Serilog.Log.Information("Received /shutdown request from {RemoteIp}", ctx.Connection.RemoteIpAddress);
+            var lifetime = ctx.RequestServices.GetService<IHostApplicationLifetime>();
+            ctx.Response.StatusCode = 202;
+            _ = Task.Run(async () =>
+            {
+                await Task.Delay(50);  // let the response flush before stopping the host
+                lifetime?.StopApplication();
+            });
+            return Task.CompletedTask;
         }
 
         static async Task GetInstalledPluginsGrasshopper(HttpContext ctx)

--- a/src/compute.geometry/Logging.cs
+++ b/src/compute.geometry/Logging.cs
@@ -66,7 +66,15 @@ namespace compute.geometry
                 // twice on the console.
                 .MinimumLevel.Override("Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware", LogEventLevel.Fatal)
                 .Enrich.With(new DynamicPortEnricher())
-                .WriteTo.Console(outputTemplate: "CG {Port} [{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}")
+                // ANSI theme embeds colors as escape sequences in the output text so they
+                // survive rhino.compute's stdout pipe (the default SystemConsoleTheme.Literate
+                // uses Console.ForegroundColor, a Win32 API that has no effect on a piped handle).
+                // applyThemeToRedirectedOutput: true is required because the sink otherwise
+                // swaps our theme for ConsoleTheme.None whenever Console.IsOutputRedirected.
+                .WriteTo.Console(
+                    outputTemplate: "CG {Port} [{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}",
+                    theme: Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme.Literate,
+                    applyThemeToRedirectedOutput: true)
                 .WriteTo.File(new ExpressionTemplate("CG {Port} [{@t:HH:mm:ss} {@l:u3}] {@m}\n{@x}"), path, rollingInterval: RollingInterval.Day, retainedFileCountLimit: limit);
 
             Log.Logger = logger.CreateLogger();

--- a/src/compute.geometry/Startup.cs
+++ b/src/compute.geometry/Startup.cs
@@ -156,6 +156,30 @@ namespace compute.geometry
                 var runheadless = pluginObject?.GetType().GetMethod("RunHeadless");
                 if (runheadless != null)
                     runheadless.Invoke(pluginObject, null);
+
+                // Only emit the "Loaded assembly: X" burst when running as a child of
+                // rhino.compute (signalled by -childof:<pid>, which populates
+                // Shutdown.ParentProcesses). In that mode CreateNoWindow=true on the child
+                // ProcessStartInfo suppresses Grasshopper's native "* Loading X assembly..."
+                // chatter, so re-emitting via Serilog restores per-plugin visibility through
+                // the CG-prefixed channel. When launched standalone the native chatter is
+                // already visible on the console; adding our burst would just duplicate it.
+                bool launchedByRhinoCompute = Shutdown.ParentProcesses != null && Shutdown.ParentProcesses.Count > 0;
+                if (launchedByRhinoCompute)
+                {
+                    try
+                    {
+                        foreach (var lib in Grasshopper.Instances.ComponentServer.Libraries)
+                        {
+                            if (lib != null && !string.IsNullOrEmpty(lib.Name))
+                                Log.Information("Loaded assembly: {Name}", lib.Name);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Warning(ex, "Unable to enumerate Grasshopper libraries after RunHeadless");
+                    }
+                }
             }
             else
             {

--- a/src/rhino.compute/ComputeChildren.cs
+++ b/src/rhino.compute/ComputeChildren.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
+using System.Net.Http;
 using System.Threading;
 using Serilog;
 
@@ -203,6 +204,21 @@ namespace rhino.compute
 
             var startInfo = new ProcessStartInfo(pathToCompute);
             startInfo.EnvironmentVariables["ASPNETCORE_HOSTINGSTARTUPASSEMBLIES"] = ""; //required for debugging compute.geometry via Visual Studio
+            // Redirect the child's stdout/stderr so we can re-emit them through the parent's
+            // single Console.Out. Multiple children writing to the OS stdout handle directly
+            // would interleave at byte level (visible when SpawnCount >= 2 spawns siblings in
+            // parallel, badly visible at 3+); routing through a single in-process TextWriter
+            // serializes the writes. The child's own "CG ..." Serilog prefix is preserved.
+            startInfo.UseShellExecute = false;
+            startInfo.RedirectStandardOutput = true;
+            startInfo.RedirectStandardError = true;
+            // Sever inheritance of rhino.compute's console handle. Without this, native code
+            // inside the child (notably Grasshopper's plugin loader) writes its "Loading X
+            // assembly..." progress straight to the inherited CONOUT$ — which bypasses our
+            // stdout pipe and ends up shared between all children, causing byte-level
+            // interleaving on the parent's console. Forcing CreateNoWindow makes those native
+            // writes either fall through to STD_OUTPUT_HANDLE (our pipe) or no-op.
+            startInfo.CreateNoWindow = true;
             var rhinoProcess = Process.GetCurrentProcess();
             Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
             string commandLineArgs = $"-port:{port} -childof:{rhinoProcess.Id}";
@@ -219,6 +235,27 @@ namespace rhino.compute
             startInfo.Arguments = commandLineArgs;
 
             var process = Process.Start(startInfo);
+            if (process != null)
+            {
+                // Lines emitted by the child's Serilog (ANSI theme) already begin with an
+                // escape sequence and a "CG {port} [...]" prefix — pass them through verbatim.
+                // Anything else (Grasshopper's raw Console.WriteLine output during plugin load,
+                // the occasional stderr write) is wrapped via childRawLogger so it picks up
+                // the same prefix, colors, and port enrichment as a normal CG line.
+                int capturedPort = port;
+                void ReEmit(string line)
+                {
+                    if (line == null) return;
+                    if (line.Length > 0 && (line[0] == '\x1B' || line.StartsWith("CG ", StringComparison.Ordinal)))
+                        Console.WriteLine(line);
+                    else
+                        childRawLogger.ForContext("Port", capturedPort).Information("{Line:l}", line);
+                }
+                process.OutputDataReceived += (s, e) => ReEmit(e.Data);
+                process.ErrorDataReceived  += (s, e) => ReEmit(e.Data);
+                process.BeginOutputReadLine();
+                process.BeginErrorReadLine();
+            }
             var start = DateTime.Now;
 
             if (waitUntilServing)
@@ -273,5 +310,81 @@ namespace rhino.compute
         }
         static object lockObject = new object();
         static Queue<Tuple<Process, int>> computeProcesses = new Queue<Tuple<Process, int>>();
+
+        // Wraps raw stdout/stderr lines from child processes (e.g. Grasshopper's plugin-load
+        // progress messages written via Console.WriteLine, which bypass the child's Serilog
+        // entirely) so they render with the same "CG {Port} [...]" prefix, color theme, and
+        // port enrichment as Serilog-emitted CG lines. Uses applyThemeToRedirectedOutput so
+        // colors still emit if rhino.compute itself ever runs with redirected stdout.
+        static readonly ILogger childRawLogger = new LoggerConfiguration()
+            .WriteTo.Console(
+                outputTemplate: "CG {Port} [{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}",
+                theme: Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme.Literate,
+                applyThemeToRedirectedOutput: true)
+            .CreateLogger();
+
+        /// <summary>
+        /// Gracefully shut down all spawned compute.geometry children. POSTs /shutdown to
+        /// each child (API key forwarded automatically since children inherit RHINO_COMPUTE_KEY
+        /// from the parent's environment, so both ends agree on the key when one is configured).
+        /// Waits up to gracefulTimeoutSeconds for each child to exit cleanly, then Kill()'s any
+        /// stragglers as a fallback. Called by Program.cs on ApplicationStopping (clean parent
+        /// exit). Hard-crash scenarios bypass this entirely — children fall back to the
+        /// existing 5-second HasExited poll in their own Shutdown.TimerTask.
+        /// </summary>
+        public static void ShutdownAllChildren(int gracefulTimeoutSeconds = 3)
+        {
+            Tuple<Process, int>[] snapshot;
+            lock (lockObject)
+            {
+                snapshot = computeProcesses.ToArray();
+                computeProcesses.Clear();
+            }
+            if (snapshot.Length == 0)
+                return;
+
+            Log.Information("Shutting down {Count} compute.geometry child process(es)", snapshot.Length);
+
+            // Short HttpClient timeout: in the Ctrl-C case the child may already be mid-shutdown
+            // (Windows broadcasts CTRL_C_EVENT to every process attached to the console), so
+            // Kestrel has stopped accepting connections and the POST will hang. We don't need
+            // the POST to succeed — the WaitForExit loop below is the actual source of truth.
+            // Healthy children respond to /shutdown in milliseconds.
+            using var client = new HttpClient { Timeout = TimeSpan.FromMilliseconds(500) };
+            if (!string.IsNullOrEmpty(Config.ApiKey))
+                client.DefaultRequestHeaders.Add("RhinoComputeKey", Config.ApiKey);
+
+            foreach (var tuple in snapshot)
+            {
+                if (tuple.Item1.HasExited) continue;
+                try
+                {
+                    var response = client.PostAsync($"http://localhost:{tuple.Item2}/shutdown", null).GetAwaiter().GetResult();
+                    Log.Debug("Shutdown request to compute.geometry on port {Port} returned {Status}", tuple.Item2, (int)response.StatusCode);
+                }
+                catch (Exception)
+                {
+                    // Expected when the child is already shutting down via its own signal
+                    // handling (typical in Ctrl-C scenarios). The WaitForExit + Kill fallback
+                    // below handles both paths uniformly.
+                }
+            }
+
+            foreach (var tuple in snapshot)
+            {
+                try
+                {
+                    if (!tuple.Item1.HasExited && !tuple.Item1.WaitForExit(gracefulTimeoutSeconds * 1000))
+                    {
+                        Log.Warning("compute.geometry on port {Port} did not exit gracefully within {Timeout}s; killing", tuple.Item2, gracefulTimeoutSeconds);
+                        tuple.Item1.Kill(entireProcessTree: true);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Log.Warning("Error while waiting for compute.geometry on port {Port} to exit: {Message}", tuple.Item2, ex.Message);
+                }
+            }
+        }
     }
 }

--- a/src/rhino.compute/Program.cs
+++ b/src/rhino.compute/Program.cs
@@ -158,7 +158,9 @@ namespace rhino.compute
                 // twice on the console.
                 .MinimumLevel.Override("Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware", LogEventLevel.Fatal)
                 .Filter.ByExcluding("RequestPath in ['/healthcheck', '/favicon.ico']")
-                .WriteTo.Console(outputTemplate: "RC  [{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}")
+                .WriteTo.Console(
+                    outputTemplate: "RC  [{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}",
+                    theme: Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme.Literate)
                 .WriteTo.File(new ExpressionTemplate("RC   [{@t:HH:mm:ss} {@l:u3}] {@m}\n{@x}"), path, rollingInterval: RollingInterval.Day, retainedFileCountLimit: limit);
             Log.Logger = loggerConfig.CreateLogger();
 
@@ -219,6 +221,18 @@ namespace rhino.compute
 
             var logger = host.Services.GetRequiredService<ILogger<ReverseProxyModule>>();
             ReverseProxyModule.InitializeConcurrentRequestLogging(logger);
+
+            // On clean shutdown of rhino.compute (Ctrl-C, IIS app pool recycle, host.StopAsync()
+            // from selfDestructTimer when parent exits), gracefully stop spawned compute.geometry
+            // children. Hard-crash scenarios (kill -9, segfault) bypass this hook — children fall
+            // back to the existing 5-second HasExited poll in their own Shutdown.cs TimerTask.
+            var lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
+            lifetime.ApplicationStopping.Register(() =>
+            {
+                Log.Information("rhino.compute shutting down; signaling compute.geometry children");
+                try { ComputeChildren.ShutdownAllChildren(); }
+                catch (Exception ex) { Log.Warning("Error during child shutdown: {Message}", ex.Message); }
+            });
 
             if (parentProcess != null)
             {


### PR DESCRIPTION
## Summary
  Two related improvements to rhino.compute's child-process lifecycle:

  ### 1. Graceful child shutdown on clean parent exit
  Today, when rhino.compute exits cleanly, it does nothing to its compute.geometry children. They self-discover the orphan via a 5-second polling loop and exit on their own. This adds a fast-path so
  children are signaled within ~50-200ms on clean parent exit, while preserving the existing polling loop as a fallback for hard-crash scenarios.

  - **`compute.geometry/FixedEndpoints.cs`** — new `POST /shutdown` endpoint. Auth-gated by the existing `ApiKeyMiddleware` (POST already required the key when configured). Returns 202 Accepted
  immediately and triggers `IHostApplicationLifetime.StopApplication()` on a background task so the response can flush before the host stops.
  - **`rhino.compute/ComputeChildren.cs`** — new public static `ShutdownAllChildren(gracefulTimeoutSeconds = 3)`. Snapshots and clears the `computeProcesses` queue, POSTs `/shutdown` to each child with
   500ms timeout (POST failures are expected when the child is racing the same Ctrl-C broadcast), waits up to 3s per child for clean exit, then `Kill(entireProcessTree: true)` on any stragglers. PR-2
  (`/shutdown-children` + `/recycle-children` endpoints) will reuse this primitive.
  - **`rhino.compute/Program.cs`** — wires `IHostApplicationLifetime.ApplicationStopping` to call `ShutdownAllChildren()`. Fires on Ctrl-C, IIS app pool recycle, and the existing `selfDestructTimer`'s
  `host.StopAsync()`.

  ### 2. Fix interleaved console output between parent and children
  Forward-port of 9.x commit `f7cb331` ("Fix interleaved child process logging in rhino.compute and add per-port prefix") — minus the `DynamicPortEnricher` half which was already on 8.x via PR #879.

  Today on 8.x, every spawned compute.geometry process inherits rhino.compute's console handle (`UseShellExecute=true`, no `CreateNoWindow` enforcement). Both Serilog output AND Grasshopper's native
  `Console.WriteLine` plugin-load chatter write straight to the shared CONOUT$ buffer, where they interleave at byte level. Visible with 1 child during shutdown (parent + child both logging); visibly
  mangled with 4 children.

  Fix:
  - **`rhino.compute/ComputeChildren.cs`** — set `startInfo.UseShellExecute = false`, `RedirectStandardOutput = true`, `RedirectStandardError = true`, `CreateNoWindow = true` so each child's output
  flows through pipes instead of the shared console. New `ReEmit` callback re-emits the lines through the parent's single `Console.WriteLine` (which is synchronized inside the process). Lines that
  already have the Serilog `CG {port} [...]` prefix pass through verbatim; raw lines (Grasshopper's "* Loading X assembly...") get wrapped via a new `childRawLogger` so they pick up the same prefix and
   colors.
  - **`compute.geometry/Logging.cs`** — `AnsiConsoleTheme.Literate` + `applyThemeToRedirectedOutput: true` on the console sink. ANSI escapes survive the stdout pipe; the default theme uses Win32 APIs
  that no-op on a piped handle.
  - **`compute.geometry/Startup.cs`** — since `CreateNoWindow=true` now suppresses Grasshopper's native plugin-load chatter, re-emit "Loaded assembly: X" via Serilog after RunHeadless. Gated on
  `launchedByRhinoCompute` so standalone compute.geometry doesn't duplicate the native chatter.
  - **`rhino.compute/Program.cs`** — `AnsiConsoleTheme.Literate` on the console sink for consistency with the children.

  Net effect: each line on the console is now an atomic write from a single `Console.WriteLine` in rhino.compute's process, no more byte-level interleaving.

  ## Test plan
  - [x] Both projects build clean (0 errors, 0 warnings introduced).
  - [x] **Multi-child shutdown**: launch rhino.compute with `--childcount 4 --spawn-on-startup`, wait for all to start, Ctrl-C. Verify clean shutdown logs from all 5 processes appear as separate,
  non-interleaved lines.
  - [x] **Single-child happy path**: launch with `--childcount 1`, send a `/grasshopper` POST, verify normal solve. Verify "* Loading X assembly..." lines now appear with the `CG NNNN [...]` prefix
  instead of bare.
  - [ ] **Idlespan still works**: launch with `--idlespan 60`, leave idle, verify children self-shut via existing `TimerTask` path.
  - [ ] **Hard-crash fallback**: kill rhino.compute via Task Manager, verify children exit within ~5s via existing `HasExited` poll.
  - [ ] **API key deployment**: with `RHINO_COMPUTE_KEY=foo`, repeat the multi-child Ctrl-C test, verify the parent's `/shutdown` POSTs include the key.
  - [ ] **Local deployment without key**: works identically (conditional header-add on parent + conditional middleware-wire on child).