### PR TITLE
rhino.compute: graceful child shutdown + lifecycle-management endpoin…

### DIFF
--- a/src/compute.geometry/FixedEndpoints.cs
+++ b/src/compute.geometry/FixedEndpoints.cs
@@ -5,6 +5,8 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using System.Linq;
 using Newtonsoft.Json.Linq;
 using Rhino.PlugIns;
@@ -21,6 +23,29 @@ namespace compute.geometry
             app.MapGet("plugins/rhino/installed", GetInstalledPluginsRhino);
             app.MapGet("plugins/gh/installed", GetInstalledPluginsGrasshopper);
             app.MapPost("cache/purge", PurgeCache);
+            app.MapPost("shutdown", ShutdownChild);
+        }
+
+        // POST /shutdown — graceful self-shutdown for this compute.geometry child. Auth-gated
+        // by ApiKeyMiddleware (POST). Used by rhino.compute when its ApplicationStopping
+        // lifecycle hook fires (clean parent exit), and by the /shutdown-children +
+        // /recycle-children endpoints in rhino.compute for manual control. The existing
+        // 5-second self-monitoring TimerTask in Shutdown.cs remains as the fallback for
+        // hard-crash scenarios where the parent dies without running its lifecycle hooks.
+        //
+        // Responds 202 Accepted immediately and triggers app.StopAsync() on a background
+        // task so the response can flush before the host stops.
+        static Task ShutdownChild(HttpContext ctx)
+        {
+            Serilog.Log.Information("Received /shutdown request from {RemoteIp}", ctx.Connection.RemoteIpAddress);
+            var lifetime = ctx.RequestServices.GetService<IHostApplicationLifetime>();
+            ctx.Response.StatusCode = 202;
+            _ = Task.Run(async () =>
+            {
+                await Task.Delay(50);  // let the response flush before stopping the host
+                lifetime?.StopApplication();
+            });
+            return Task.CompletedTask;
         }
 
         static void HomePage(HttpContext context)

--- a/src/rhino.compute/ComputeChildren.cs
+++ b/src/rhino.compute/ComputeChildren.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
+using System.Net.Http;
 using System.Threading;
 using Serilog;
 
@@ -220,10 +221,16 @@ namespace rhino.compute
                 pendingSpawnPorts.Add(port);
             }
 
-            // Start the process and wait outside the lock so that other threads can
-            // continue serving requests through already-ready children while this one loads.
-            // Use try/catch/finally so that pendingSpawnPorts is always cleaned up — even if
-            // Process.Start or the startup wait throws — preventing permanent capacity reduction.
+            StartChildOnReservedPort(pathToCompute, port);
+        }
+
+        // Performs the actual spawn for a port that has ALREADY been added to pendingSpawnPorts
+        // under the lock. Spawns outside the lock; in finally, re-acquires the lock to remove
+        // the reservation and enqueue on success. Always pulses lockObject so threads waiting
+        // in GetComputeServerBaseUrl (via Monitor.Wait) are woken whether we succeed or fail.
+        // Shared between LaunchCompute() (auto-fill path) and LaunchChild() (manual path).
+        static void StartChildOnReservedPort(string pathToCompute, int port)
+        {
             Process process = null;
             bool started = false;
             try
@@ -409,6 +416,259 @@ namespace rhino.compute
 
         // Returns true if any TCP listener is currently bound to the given port.
         static bool IsPortOpen(int port) => GetListeningPorts().Contains(port);
+
+        /// <summary>
+        /// Gracefully shut down compute.geometry children. POSTs /shutdown to each child
+        /// (API key forwarded automatically since children inherit RHINO_COMPUTE_KEY from the
+        /// parent's environment, so both ends agree on the key when one is configured). Waits
+        /// up to <paramref name="gracefulTimeoutSeconds"/> for each child to exit cleanly,
+        /// then Kill()'s any stragglers as a fallback.
+        ///
+        /// <para>Called by Program.cs on ApplicationStopping (clean parent exit, no respawn),
+        /// and by the /shutdown-children and /recycle-children endpoints (with respawn=true for
+        /// the latter). Hard-crash scenarios bypass this entirely — children fall back to the
+        /// existing 5-second HasExited poll in their own Shutdown.TimerTask.</para>
+        /// </summary>
+        /// <param name="portFilter">When non-null, only the child on this port is shut down
+        /// (others are left running). When null, all children are shut down.</param>
+        /// <param name="respawn">When true, spawn one fresh replacement per shut-down child,
+        /// sequentially (one at a time) so the queue is never empty mid-recycle if other
+        /// children are handling traffic. Respects SpawnCount.</param>
+        /// <returns>Ports that were shut down, and ports of any newly-spawned replacements.</returns>
+        public static (int[] shutdown, int[] spawned) ShutdownChildren(
+            int? portFilter = null,
+            bool respawn = false,
+            int gracefulTimeoutSeconds = 3)
+        {
+            Tuple<Process, int>[] toShutdown;
+            lock (lockObject)
+            {
+                if (portFilter.HasValue)
+                {
+                    var match = new List<Tuple<Process, int>>();
+                    var keep = new Queue<Tuple<Process, int>>();
+                    foreach (var t in computeProcesses)
+                    {
+                        if (t.Item2 == portFilter.Value)
+                            match.Add(t);
+                        else
+                            keep.Enqueue(t);
+                    }
+                    computeProcesses = keep;
+                    toShutdown = match.ToArray();
+                }
+                else
+                {
+                    toShutdown = computeProcesses.ToArray();
+                    computeProcesses.Clear();
+                }
+            }
+            if (toShutdown.Length == 0)
+                return (Array.Empty<int>(), Array.Empty<int>());
+
+            Log.Information("Shutting down {Count} compute.geometry child process(es)", toShutdown.Length);
+
+            // Short HttpClient timeout: in the Ctrl-C case the child may already be mid-shutdown
+            // (Windows broadcasts CTRL_C_EVENT to every process attached to the console), so
+            // Kestrel has stopped accepting connections and the POST will hang. We don't need
+            // the POST to succeed — the WaitForExit loop below is the actual source of truth.
+            // Healthy children respond to /shutdown in milliseconds.
+            using var client = new HttpClient { Timeout = TimeSpan.FromMilliseconds(500) };
+            if (!string.IsNullOrEmpty(Config.ApiKey))
+                client.DefaultRequestHeaders.Add("RhinoComputeKey", Config.ApiKey);
+
+            foreach (var tuple in toShutdown)
+            {
+                if (tuple.Item1.HasExited) continue;
+                try
+                {
+                    var response = client.PostAsync($"http://localhost:{tuple.Item2}/shutdown", null).GetAwaiter().GetResult();
+                    Log.Debug("Shutdown request to compute.geometry on port {Port} returned {Status}", tuple.Item2, (int)response.StatusCode);
+                }
+                catch (Exception)
+                {
+                    // Expected when the child is already shutting down via its own signal
+                    // handling (typical in Ctrl-C scenarios). The WaitForExit + Kill fallback
+                    // below handles both paths uniformly.
+                }
+            }
+
+            foreach (var tuple in toShutdown)
+            {
+                try
+                {
+                    if (!tuple.Item1.HasExited && !tuple.Item1.WaitForExit(gracefulTimeoutSeconds * 1000))
+                    {
+                        Log.Warning("compute.geometry on port {Port} did not exit gracefully within {Timeout}s; killing", tuple.Item2, gracefulTimeoutSeconds);
+                        tuple.Item1.Kill(entireProcessTree: true);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Log.Warning("Error while waiting for compute.geometry on port {Port} to exit: {Message}", tuple.Item2, ex.Message);
+                }
+            }
+
+            var shutdownPorts = toShutdown.Select(t => t.Item2).ToArray();
+            int[] spawnedPorts = Array.Empty<int>();
+            if (respawn)
+            {
+                var spawned = new List<int>();
+                foreach (var _ in shutdownPorts)
+                {
+                    int countBefore;
+                    lock (lockObject)
+                        countBefore = computeProcesses.Count;
+                    try
+                    {
+                        LaunchCompute();
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Warning("Error during recycle respawn: {Message}", ex.Message);
+                        break;
+                    }
+                    lock (lockObject)
+                    {
+                        if (computeProcesses.Count > countBefore)
+                            spawned.Add(computeProcesses.Last().Item2);
+                    }
+                }
+                spawnedPorts = spawned.ToArray();
+            }
+
+            return (shutdownPorts, spawnedPorts);
+        }
+
+        /// <summary>
+        /// Fill the compute.geometry child pool up to <see cref="SpawnCount"/>. If already at
+        /// or above SpawnCount, no-op (returns empty array). Used by the POST /launch-children
+        /// endpoint. Honors <see cref="LoadChildrenSequentially"/> — same flag, same semantics
+        /// as the auto-spawn path in <see cref="GetComputeServerBaseUrl"/>: parallel by default
+        /// for fast warmup, sequential when the flag is set. Always blocks until all spawns
+        /// complete so the response can report the spawned ports accurately.
+        /// </summary>
+        /// <returns>Ports newly spawned by this call.</returns>
+        public static int[] LaunchChildren()
+        {
+            int targetSpawns;
+            int[] existingPortsSnapshot;
+            lock (lockObject)
+            {
+                int currentCount = computeProcesses.Count + pendingSpawnPorts.Count;
+                targetSpawns = Math.Max(0, SpawnCount - currentCount);
+                existingPortsSnapshot = computeProcesses.Select(t => t.Item2).ToArray();
+            }
+            if (targetSpawns == 0)
+                return Array.Empty<int>();
+
+            if (LoadChildrenSequentially)
+            {
+                // One spawn at a time — caps peak Rhino+Grasshopper memory at one extra child
+                // mid-load. Each LaunchCompute() call blocks until the spawned child's port opens.
+                for (int i = 0; i < targetSpawns; i++)
+                    LaunchCompute();
+            }
+            else
+            {
+                // Parallel spawning for fast warmup. Each task does its own port reservation +
+                // start + enqueue under the pendingSpawnPorts protocol, so concurrent spawns
+                // can't collide on a port.
+                var tasks = new System.Threading.Tasks.Task[targetSpawns];
+                for (int i = 0; i < targetSpawns; i++)
+                    tasks[i] = System.Threading.Tasks.Task.Run(() => LaunchCompute());
+                System.Threading.Tasks.Task.WaitAll(tasks);
+            }
+
+            // Diff the queue against the pre-spawn snapshot to find newly-added ports.
+            // (Order is non-deterministic in parallel mode; that's fine.)
+            lock (lockObject)
+            {
+                var existingSet = new HashSet<int>(existingPortsSnapshot);
+                return computeProcesses
+                    .Select(t => t.Item2)
+                    .Where(p => !existingSet.Contains(p))
+                    .ToArray();
+            }
+        }
+
+        /// <summary>
+        /// Spawn exactly one compute.geometry child. Bypasses the SpawnCount auto-fill cap so
+        /// callers can push above the configured baseline, but enforces the absolute MaxChildren
+        /// ceiling. Used by the POST /launch-child endpoint.
+        /// </summary>
+        /// <param name="requestedPort">Optional port to bind. When null, uses the next available
+        /// port in the 6001-6256 range. When specified, validates that the port is in 6001-65535,
+        /// not held by an existing child, not already being spawned, and not already bound externally.</param>
+        /// <returns>The port the new child was spawned on.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">When requestedPort is outside 6001-65535.</exception>
+        /// <exception cref="InvalidOperationException">When the port is already in use, the pool
+        /// is at MaxChildren, no port is available, or compute.geometry.exe is missing.</exception>
+        public static int LaunchChild(int? requestedPort)
+        {
+            string pathToCompute = FindComputeExecutablePath();
+            if (pathToCompute == null)
+                throw new InvalidOperationException("compute.geometry executable not found.");
+
+            var listeningPorts = GetListeningPorts();
+            int port;
+            lock (lockObject)
+            {
+                if (computeProcesses.Count + pendingSpawnPorts.Count >= MaxChildren)
+                    throw new InvalidOperationException($"Maximum child count reached ({MaxChildren}).");
+
+                if (requestedPort.HasValue)
+                {
+                    if (requestedPort.Value < 6001 || requestedPort.Value > 65535)
+                        throw new ArgumentOutOfRangeException(nameof(requestedPort),
+                            "Port must be in range 6001-65535.");
+                    if (computeProcesses.Any(t => t.Item2 == requestedPort.Value))
+                        throw new InvalidOperationException(
+                            $"Port {requestedPort.Value} is already in use by an existing child.");
+                    if (pendingSpawnPorts.Contains(requestedPort.Value))
+                        throw new InvalidOperationException(
+                            $"Port {requestedPort.Value} is already being spawned.");
+                    if (listeningPorts.Contains(requestedPort.Value))
+                        throw new InvalidOperationException(
+                            $"Port {requestedPort.Value} is already in use.");
+                    port = requestedPort.Value;
+                }
+                else
+                {
+                    var usedPorts = new HashSet<int>(computeProcesses.Select(t => t.Item2));
+                    usedPorts.UnionWith(pendingSpawnPorts);
+                    port = FindFreePort(usedPorts, listeningPorts);
+                    if (port == 0)
+                        throw new InvalidOperationException(
+                            "No available port found in the 6001-6256 range.");
+                }
+                pendingSpawnPorts.Add(port);
+            }
+
+            StartChildOnReservedPort(pathToCompute, port);
+
+            // Verify the spawn actually landed in the queue (startup might have timed out
+            // or failed inside StartChildOnReservedPort, in which case it's gone from
+            // pendingSpawnPorts but not in computeProcesses).
+            lock (lockObject)
+            {
+                if (!computeProcesses.Any(t => t.Item2 == port))
+                    throw new InvalidOperationException(
+                        $"Failed to spawn child on port {port} (startup timed out or process exited).");
+            }
+            return port;
+        }
+
+        /// <summary>Returns the current count of tracked compute.geometry children.</summary>
+        public static int CurrentChildCount
+        {
+            get
+            {
+                lock (lockObject)
+                    return computeProcesses.Count;
+            }
+        }
+
         static object lockObject = new object();
         static Queue<Tuple<Process, int>> computeProcesses = new Queue<Tuple<Process, int>>();
         // Ports for which a child process has been started but has not yet been confirmed

--- a/src/rhino.compute/Program.cs
+++ b/src/rhino.compute/Program.cs
@@ -247,6 +247,18 @@ requests while the child processes are launching.")]
             var logger = host.Services.GetRequiredService<ILogger<ReverseProxyModule>>();
             ReverseProxyModule.InitializeConcurrentRequestLogging(logger);
 
+            // On clean shutdown of rhino.compute (Ctrl-C, IIS app pool recycle, host.StopAsync()
+            // from selfDestructTimer when parent exits), gracefully stop spawned compute.geometry
+            // children. Hard-crash scenarios (kill -9, segfault) bypass this hook — children fall
+            // back to the existing 5-second HasExited poll in their own Shutdown.cs TimerTask.
+            var lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
+            lifetime.ApplicationStopping.Register(() =>
+            {
+                Log.Information("rhino.compute shutting down; signaling compute.geometry children");
+                try { ComputeChildren.ShutdownChildren(); }
+                catch (Exception ex) { Log.Warning("Error during child shutdown: {Message}", ex.Message); }
+            });
+
             if (parentProcess != null)
             {
                 selfDestructTimer = new System.Timers.Timer(1000);

--- a/src/rhino.compute/ReverseProxy.cs
+++ b/src/rhino.compute/ReverseProxy.cs
@@ -95,25 +95,168 @@ namespace rhino.compute
                 context.Response.Redirect("https://www.rhino3d.com/compute");
                 return Task.CompletedTask;
             });
-            app.MapGet("/activechildren", async (context) =>
-            {
-                bool initialize = true;
-                if (context.Request.Query.TryGetValue("initialize", out var initValue)
-                    && bool.TryParse(initValue, out var parsed))
-                {
-                    initialize = parsed;
-                }
-                if (initialize)
-                    InitializeChildren();
-                await context.Response.WriteAsync($"{ComputeChildren.ActiveComputeCount}");
-            });
+            // /activechildren is the long-standing slug-style endpoint name. /active-children is a
+            // kebab-case alias matching the style of the newer /shutdown-children, /recycle-children
+            // etc. Both routes share the same handler. The original slug stays for backward compat.
+            app.MapGet("/activechildren", ActiveChildrenEndpoint);
+            app.MapGet("/active-children", ActiveChildrenEndpoint);
             app.MapGet("/launch", LaunchChildren);
             app.MapGet("/favicon.ico", async (context) => await context.Response.WriteAsync("Handled"));
+
+            // Child-lifecycle management endpoints. All POST so they're auth-gated by the
+            // existing ApiKeyMiddleware when RHINO_COMPUTE_KEY is configured. Registered before
+            // the catch-all proxy route below so they're not forwarded to a compute.geometry child.
+            app.MapPost("/shutdown-children", ShutdownChildrenEndpoint);
+            app.MapPost("/recycle-children",  RecycleChildrenEndpoint);
+            app.MapPost("/launch-children",   LaunchChildrenEndpoint);
+            app.MapPost("/launch-child",      LaunchChildEndpoint);
+
+            // Guard against accidental hits on the internal /shutdown endpoint. Without this,
+            // the catch-all proxy below would forward POST /shutdown to one round-robin-selected
+            // compute.geometry child, silently killing it (it would respawn on the next
+            // /grasshopper request, but the side-effect is surprising). The 400 with a hint
+            // points users at the right endpoint instead.
+            app.MapPost("/shutdown", async (HttpResponse res) =>
+            {
+                res.StatusCode = 400;
+                await res.WriteAsJsonAsync(new
+                {
+                    error = "POST /shutdown is internal-only (rhino.compute → compute.geometry). " +
+                            "Use POST /shutdown-children to shut down children from outside the cluster."
+                });
+            });
 
             // routes that are proxied to compute.geometry
             app.MapGet("/{*uri}", ReverseProxyGet);
             app.MapPost("/grasshopper", ReverseProxyPost);
             app.MapPost("/{*uri}", ReverseProxyPost);
+        }
+
+        // GET /activechildren and GET /active-children — return the count of active compute.geometry
+        // child processes. ?initialize=true (default) spawns up to SpawnCount children if none are
+        // running, then returns the count. ?initialize=false just reports the count without spawning,
+        // useful for passive monitoring that shouldn't trigger billing.
+        static async Task ActiveChildrenEndpoint(HttpContext context)
+        {
+            bool initialize = true;
+            if (context.Request.Query.TryGetValue("initialize", out var initValue)
+                && bool.TryParse(initValue, out var parsed))
+            {
+                initialize = parsed;
+            }
+            if (initialize)
+                InitializeChildren();
+            await context.Response.WriteAsync($"{ComputeChildren.ActiveComputeCount}");
+        }
+
+        // POST /shutdown-children — gracefully shut down children. No params = all; ?port=N
+        // = just that one. Does not respawn. After shutdown-all, the next /grasshopper request
+        // triggers an auto-spawn back to SpawnCount; to confirm count without re-spawning, poll
+        // /activechildren?initialize=false.
+        static async Task ShutdownChildrenEndpoint(HttpRequest req, HttpResponse res)
+        {
+            if (!TryParsePortFilter(req, out int? portFilter, out string parseError))
+            {
+                res.StatusCode = 400;
+                await res.WriteAsJsonAsync(new { error = parseError });
+                return;
+            }
+            var (shutdown, _) = ComputeChildren.ShutdownChildren(portFilter, respawn: false);
+            await res.WriteAsJsonAsync(new
+            {
+                shutdown,
+                active = ComputeChildren.CurrentChildCount,
+            });
+        }
+
+        // POST /recycle-children — shut down + respawn. No params = all; ?port=N = just that one.
+        // Sequential (waits for each replacement to be serving before moving on) so the queue
+        // never drops to zero mid-recycle when other children are handling traffic.
+        static async Task RecycleChildrenEndpoint(HttpRequest req, HttpResponse res)
+        {
+            if (!TryParsePortFilter(req, out int? portFilter, out string parseError))
+            {
+                res.StatusCode = 400;
+                await res.WriteAsJsonAsync(new { error = parseError });
+                return;
+            }
+            var (shutdown, spawned) = ComputeChildren.ShutdownChildren(portFilter, respawn: true);
+            await res.WriteAsJsonAsync(new
+            {
+                shutdown,
+                spawned,
+                active = ComputeChildren.CurrentChildCount,
+            });
+        }
+
+        // POST /launch-children — fill the pool up to SpawnCount. No-op when already at or above.
+        // To raise capacity permanently, restart rhino.compute with a higher --childcount;
+        // /launch-children only fills to the configured baseline. Honors LoadChildrenSequentially.
+        static async Task LaunchChildrenEndpoint(HttpRequest req, HttpResponse res)
+        {
+            var spawned = ComputeChildren.LaunchChildren();
+            await res.WriteAsJsonAsync(new
+            {
+                spawned,
+                active = ComputeChildren.CurrentChildCount,
+            });
+        }
+
+        // POST /launch-child — add one child to the pool. Can push above SpawnCount up to the
+        // MaxChildren cap. ?port=N requests a specific port; otherwise picks the next free one.
+        // 400 = malformed/out-of-range port. 409 = port in use. 503 = at MaxChildren.
+        static async Task LaunchChildEndpoint(HttpRequest req, HttpResponse res)
+        {
+            int? requestedPort = null;
+            if (req.Query.TryGetValue("port", out var portValue) && !string.IsNullOrEmpty(portValue))
+            {
+                if (!int.TryParse(portValue, out int parsed))
+                {
+                    res.StatusCode = 400;
+                    await res.WriteAsJsonAsync(new { error = "Port must be an integer." });
+                    return;
+                }
+                requestedPort = parsed;
+            }
+            try
+            {
+                int port = ComputeChildren.LaunchChild(requestedPort);
+                await res.WriteAsJsonAsync(new { spawned = new[] { port } });
+            }
+            catch (ArgumentOutOfRangeException ex)
+            {
+                res.StatusCode = 400;
+                await res.WriteAsJsonAsync(new { error = ex.Message });
+            }
+            catch (InvalidOperationException ex)
+            {
+                // Distinguish "max children reached" (503) from "port in use" or "no port available" (409).
+                res.StatusCode = ex.Message.StartsWith("Maximum child count reached") ? 503 : 409;
+                await res.WriteAsJsonAsync(new { error = ex.Message });
+            }
+        }
+
+        // Parses optional ?port=N from the query. Returns false with errorMessage when the
+        // value is present but unparseable or out of range. Returns true with portFilter=null
+        // when no port parameter was supplied (caller should operate on all children).
+        static bool TryParsePortFilter(HttpRequest req, out int? portFilter, out string errorMessage)
+        {
+            portFilter = null;
+            errorMessage = null;
+            if (!req.Query.TryGetValue("port", out var portValue) || string.IsNullOrEmpty(portValue))
+                return true;
+            if (!int.TryParse(portValue, out int parsed))
+            {
+                errorMessage = "Port must be an integer.";
+                return false;
+            }
+            if (parsed < 6001 || parsed > 65535)
+            {
+                errorMessage = "Port must be in range 6001-65535.";
+                return false;
+            }
+            portFilter = parsed;
+            return true;
         }
 
         static async Task LaunchChildren(HttpRequest request, HttpResponse response)


### PR DESCRIPTION
…ts (port of 8.x #918/#919/#920)

## Summary
  Bundled 9.x port of three 8.x PRs (#918, #919, #920) — all the child-lifecycle work landed on 8.x today. The 9.x port is smaller than the sum of the 8.x PRs because 9.x already has:
  - The interleave-fix portion of #918 (via 9.x's original f7cb331 from 2026-05-20).
  - All of Luis's spawning refactor (via 9.x's pre-existing structure that #920 forward-ported to 8.x).
  - The `--load-children-sequentially` flag (via 9.x commit 2b3a5e1).

  What this PR brings forward to 9.x:

  ### From PR #918 (graceful child shutdown)
  - **`compute.geometry/FixedEndpoints.cs`** — new `POST /shutdown` endpoint. Auth-gated by `ApiKeyMiddleware` (POST). Returns 202 Accepted and triggers `IHostApplicationLifetime.StopApplication()` on
  a background task so the response can flush before the host stops.
  - **`rhino.compute/ComputeChildren.cs`** — new `ShutdownChildren(int? portFilter, bool respawn, int gracefulTimeoutSeconds)` method. POSTs `/shutdown` to each child with a 500ms timeout (failures are
   expected when racing the same Ctrl-C broadcast), waits up to 3s per child for clean exit, then `Kill(entireProcessTree: true)` on stragglers.
  - **`rhino.compute/Program.cs`** — wires `IHostApplicationLifetime.ApplicationStopping` to call `ShutdownChildren()`. Fires on Ctrl-C, IIS recycle, and the existing `selfDestructTimer`'s
  `host.StopAsync()`.

  ### From PR #919 (new endpoints)
  - Four new POST endpoints on rhino.compute, all auth-gated:
    - `POST /shutdown-children` (optional `?port=N`) — same behavior as `ShutdownChildren()` direct call.
    - `POST /recycle-children` (optional `?port=N`) — shut down + sequentially respawn.
    - `POST /launch-children` — fill to `SpawnCount`. Honors `LoadChildrenSequentially`.
    - `POST /launch-child` (optional `?port=N`) — add one child; can push above `SpawnCount` up to `MaxChildren = 64`. Validates 400/409/503 appropriately.
  - `GET /active-children` kebab-case alias for the legacy `GET /activechildren`. Same handler, both routes work.
  - `POST /shutdown` 400-guard on rhino.compute itself, pointing at `/shutdown-children` (prevents accidental hits from falling through the catch-all proxy and silently killing one round-robin child).

  ### From PR #920 (refactor + flag)
  - 9.x already has the refactor and the `--load-children-sequentially` flag, so most of this PR's work is already there. **What's new in this 9.x port:**
    - Extracted `StartChildOnReservedPort` from `LaunchCompute()` so the new `LaunchChild()` can share the same try/catch/finally + Monitor.PulseAll machinery without duplication. `LaunchCompute()`
  keeps its existing public contract.
    - `LaunchChildren()` honors `LoadChildrenSequentially` — parallel `Task.Run` + `WaitAll` by default, serial loop when the flag is set. Matches the behavior in `GetComputeServerBaseUrl`.
    - `LaunchChild()` and `ShutdownChildren()` integrate with the existing `pendingSpawnPorts` reservation set so concurrent spawns don't collide.

  ### What does NOT change
  - 9.x's existing `compute.geometry/Shutdown.TimerTask` (the 5-second `parentProcess.HasExited` poll + idle-span check) — preserved as the fallback for hard-crash scenarios.
  - 9.x's existing `LaunchCompute()` public contract — still parameterless, still respects SpawnCount.
  - Legacy `/launch?children=N&parent=PID` IPC endpoint — unchanged.
  - All other 9.x behavior.

  ### Branches now structurally aligned
  After this PR, 8.x and 9.x have essentially the same child-lifecycle surface: same endpoints, same `ComputeChildren` public API, same internal spawn flow, same flag. Per-branch refinements (e.g.,
  9.x's Model Object support) stay 9.x-only as intended.

  9.x changelog updates deferred per standing instruction.

  ## Test plan
  - [ ] Build succeeds for both projects (verified locally: 0 errors).
  - [ ] All four new endpoints work end-to-end (`/shutdown-children`, `/recycle-children`, `/launch-children`, `/launch-child`) with and without `?port=N` — including 400/409/503 error paths on
  `/launch-child`.
  - [ ] `POST /shutdown` returns 400 with hint.
  - [ ] `GET /active-children` mirrors `GET /activechildren`.
  - [ ] Graceful Ctrl-C shutdown produces clean ~1-second exit.
  - [ ] `POST /launch-children` is parallel by default, sequential with `--load-children-sequentially`.
  - [ ] `POST /recycle-children` always sequential.
  - [ ] Existing `/launch?children=N&parent=PID` still works for Rhino IPC.
  - [ ] `--load-children-sequentially` flag still affects the auto-fill in `GetComputeServerBaseUrl`.