### PR TITLE
compute.geometry: stream-deserialize POST bodies on /io and /{*uri}

### DIFF
--- a/src/compute.geometry/GeometryEndPoint.cs
+++ b/src/compute.geometry/GeometryEndPoint.cs
@@ -367,21 +367,34 @@ namespace compute.geometry
                 return;
             }
 
-            var jsonString = await new System.IO.StreamReader(context.Request.Body).ReadToEndAsync();
+            // The POST body is expected to be a JSON array of arguments. Stream-deserialize
+            // directly into a JArray rather than materializing the body as a string first —
+            // saves ~MaxRequestSize bytes of peak memory per request (default 50 MB).
+            // Reject anything that's not a JSON array (other JSON shapes, malformed JSON, or an
+            // empty body) with a 400 — this is a client-input boundary, so a bad shape is a 400,
+            // not a 500.
+            //
+            // When the debug StopAt.BodyToString checkpoint is requested, fall back to the
+            // original body-to-string read so the timing semantics of that profiling stage are
+            // preserved exactly (used by some workflows to measure body-receive latency).
+            Newtonsoft.Json.Linq.JArray ja = null;
             if (StopAt.BodyToString == stopat)
             {
+                var jsonString = await new System.IO.StreamReader(context.Request.Body).ReadToEndAsync();
                 await context.Response.WriteAsync($"{(DateTime.Now - start).TotalSeconds}");
                 return;
             }
-
-            // The POST body is expected to be a JSON array of arguments. Deserialize to the
-            // expected shape and reject anything else (non-array JSON, malformed JSON, or an
-            // empty body) with a 400 — otherwise a null `ja` would NullReference below. This
-            // is a client-input boundary, so a bad shape is a 400, not a 500.
-            Newtonsoft.Json.Linq.JArray ja = null;
-            if (!string.IsNullOrWhiteSpace(jsonString))
+            // Async reads via JsonTextReader.ReadAsync + JArray.LoadAsync so the underlying
+            // reads on Request.Body are async — Kestrel disallows synchronous IO on the
+            // request stream by default.
+            using (var streamReader = new System.IO.StreamReader(context.Request.Body))
+            using (var jsonReader = new Newtonsoft.Json.JsonTextReader(streamReader))
             {
-                try { ja = JsonConvert.DeserializeObject(jsonString) as Newtonsoft.Json.Linq.JArray; }
+                try
+                {
+                    if (await jsonReader.ReadAsync() && jsonReader.TokenType == Newtonsoft.Json.JsonToken.StartArray)
+                        ja = await Newtonsoft.Json.Linq.JArray.LoadAsync(jsonReader);
+                }
                 catch (Newtonsoft.Json.JsonException) { ja = null; }
             }
             if (ja == null)

--- a/src/compute.geometry/ResthopperEndpoints.cs
+++ b/src/compute.geometry/ResthopperEndpoints.cs
@@ -195,11 +195,24 @@ namespace compute.geometry
             string fileName = String.Empty;
             if (asPost)
             {
-                var body = await new System.IO.StreamReader(ctx.Request.Body).ReadToEndAsync();
-                if (body.StartsWith("[") && body.EndsWith("]"))
-                    body = body.Substring(1, body.Length - 2);
-
-                Schema input = JsonConvert.DeserializeObject<Schema>(body);
+                // Stream-deserialize the request body asynchronously instead of materializing
+                // it as a string first. Saves ~MaxRequestSize bytes of peak memory per request
+                // (default 50 MB) since we don't hold both the stream buffer AND a full string
+                // copy in memory at the same time. Uses Newtonsoft's async APIs (ReadFromAsync,
+                // ReadAsync) so the underlying reads on Request.Body are async — Kestrel
+                // disallows synchronous IO on the request stream by default.
+                //
+                // Historical request shape: the body is sometimes wrapped in a single-element
+                // JSON array (`[{...}]`). Detect that via the parsed token kind and unwrap.
+                Schema input;
+                using (var streamReader = new System.IO.StreamReader(ctx.Request.Body))
+                using (var jsonReader = new Newtonsoft.Json.JsonTextReader(streamReader))
+                {
+                    var token = await Newtonsoft.Json.Linq.JToken.ReadFromAsync(jsonReader);
+                    if (token is Newtonsoft.Json.Linq.JArray ja && ja.Count > 0)
+                        token = ja[0];
+                    input = token.ToObject<Schema>();
+                }
 
                 string httpType = ctx.Request.IsHttps ? "HTTPS" : "HTTP";
                 string endpoint = ctx.GetEndpoint().DisplayName;


### PR DESCRIPTION
 ## Summary
  Stream-deserialize POST bodies on two compute.geometry endpoints instead of materializing them as strings first. Saves ~MaxRequestSize bytes of peak memory per request (default 50 MB) since the body
  is no longer held both as a stream buffer AND as a full string copy at the same time.

  ### Two sites changed

  - **`ResthopperEndpoints.GetIoNamesHelper`** (`/io` POST handler) — body was read into a string, optionally `[...]`-trimmed, then JSON-deserialized into a `Schema`. The string was discarded after.
  Now uses `JsonTextReader` + `JToken.ReadFromAsync` directly on the request stream. The historical `[Schema]` array-wrapped shape is handled by checking the parsed token kind and unwrapping `[0]` —
  cleaner than the previous string-trim that only worked when the brackets were the literal first/last characters.

  - **`GeometryEndPoint`'s POST handler** (the `/{*uri}` reflection-dispatch route) — body was read into a string, then JSON-deserialized into a `JArray`. The string was only used for the deserialize.
  Now uses `JsonTextReader.ReadAsync` + `JArray.LoadAsync` directly on the request stream. Same 400-on-non-array-shape behavior preserved.

  Both sites use Newtonsoft's async APIs (`ReadFromAsync`, `ReadAsync`, `LoadAsync`) — Kestrel disallows synchronous IO on `Request.Body` by default, so the sync variants of those readers would throw
  "Synchronous operations are disallowed".

  ### One site intentionally NOT changed

  `ResthopperEndpoints.Grasshopper` (`/grasshopper` POST handler) — the body string is also used as the cache key for `DataCache.GetCachedSolveResults` / `SetCachedSolveResults`. Removing the
  materialization would require changing the cache to use a hash-based key, which is a separate refactor with its own consequences. Filed for later.

  ### Edge case: `StopAt.BodyToString` debug checkpoint

  The `GeometryEndPoint` handler exposes a `?stopat=N` query param (integer enum value) that lets debug clients measure timing of intermediate processing stages. The `BodyToString` stage (value `2`)
  was specifically `read body into string and return immediately`. Streaming deserialize would change that timing semantic, so the original body-to-string read is preserved when `BodyToString` is
  requested. The normal path uses streaming.

  May be safe to remove `BodyToString` entirely in the future if nobody is actually using it for profiling — left in for now per user input.

  ## Test plan
  - [x] Build succeeds (0 errors, only pre-existing warnings unrelated to this change).
  - [x] `POST /io` round-trip via Hops succeeds (basic Schema deserialize via streaming).
  - [x] `POST /rhino/geometry/point3d/distanceto-point3d_point3d` with `[{"X":1,"Y":2,"Z":3},{"X":4,"Y":5,"Z":7}]` returns the expected distance (reflection handler with JArray streaming).
  - [x] `?stopat=2` (BodyToString) returns a timing number — fallback to body-to-string read preserved.
  - [ ] `POST /io` with `[Schema]` array-wrapped historical shape still parses (the JArray-unwrap path).
  - [ ] `POST /{*uri}` with a non-array body (e.g. `{}`) still returns 400.