### PR TITLE
Hops: narrow catch(Exception) blocks based on per-site review

### DIFF
--- a/src/hops/HopsComponent.cs
+++ b/src/hops/HopsComponent.cs
@@ -668,8 +668,9 @@ namespace Hops
                         }
                     }
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
+                    HopsLog.Log.Debug(ex, "Failed to load function-source menu for {SourcePath}", row.SourcePath);
                 }
             }
             else if (Directory.Exists(row.SourcePath))
@@ -703,7 +704,10 @@ namespace Hops
                     {
                         Instances.DocumentEditor.ScriptAccess_OpenDocument(ti.Name);
                     }
-                    catch (Exception) { }
+                    catch (Exception ex)
+                    {
+                        HopsLog.Log.Debug(ex, "Failed to open document {DocumentName}", ti.Name);
+                    }
                     break;
             }
 
@@ -990,8 +994,10 @@ for value in values:
             {
                 return JsonConvert.DeserializeObject<string>(data);
             }
-            catch (Exception)
+            catch (Newtonsoft.Json.JsonException)
             {
+                // Intentional fallback: when the data isn't valid JSON-encoded string syntax,
+                // treat it as already-decoded and just unescape any backslash sequences.
                 return System.Text.RegularExpressions.Regex.Unescape(data);
             }
         }

--- a/src/hops/RemoteDefinition.cs
+++ b/src/hops/RemoteDefinition.cs
@@ -72,7 +72,7 @@ namespace Hops
                         message = m;
                 }
             }
-            catch (Exception)
+            catch (Newtonsoft.Json.JsonException)
             {
                 // not JSON — keep the raw body
             }
@@ -518,8 +518,9 @@ namespace Hops
                             }
                         }
                     }
-                    catch(Exception)
+                    catch (Exception ex)
                     {
+                        HopsLog.Log.Debug(ex, "Failed to parse custom icon for remote definition at {Path}", Path);
                     }
                 }
 
@@ -659,8 +660,10 @@ namespace Hops
             {
                 return JsonConvert.DeserializeObject<Resthopper.IO.Schema>(data);
             }
-            catch (Exception)
+            catch (Newtonsoft.Json.JsonException)
             {
+                // Method-name promises "safe" — caller treats null as parse failure and
+                // handles it via the bad-schema / status-code paths.
             }
             return null;
         }
@@ -1031,8 +1034,10 @@ namespace Hops
             {
                 return JsonConvert.DeserializeObject<string>(objData);
             }
-            catch (Exception)
+            catch (Newtonsoft.Json.JsonException)
             {
+                // Intentional fallback: when objData isn't valid JSON-encoded string syntax,
+                // treat it as already-decoded and just strip wrapping quotes / unescape.
                 return MaybeUnescapeJsonString(objData.Trim('"'));
             }
         }
@@ -1165,9 +1170,11 @@ namespace Hops
                         return false;
                     }
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ex is FormatException || ex is OverflowException || ex is InvalidCastException)
                 {
-                    errors.Add(ex.ToString());
+                    // Conversion of `item` or `min` to double failed. Surface the short error
+                    // message rather than the full ex.ToString() (which includes the stack trace).
+                    errors.Add($"{name} value could not be evaluated for the minimum-bound check: {ex.Message}");
                     return false;
                 }
 
@@ -1185,9 +1192,11 @@ namespace Hops
                         return false;
                     }
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ex is FormatException || ex is OverflowException || ex is InvalidCastException)
                 {
-                    errors.Add(ex.ToString());
+                    // Conversion of `item` or `max` to double failed. Surface the short error
+                    // message rather than the full ex.ToString() (which includes the stack trace).
+                    errors.Add($"{name} value could not be evaluated for the maximum-bound check: {ex.Message}");
                     return false;
                 }
             }


### PR DESCRIPTION
## Summary
  Tightened 8 of the 14 `catch (Exception)` blocks in Hops based on a per-site review. Each was an empty-catch swallow or used the broad type when the actual intent was narrower. The remaining 6 sites
  were left alone — they already surface to the user via `HopsAddRuntimeMessage` or are correctly catch-all by design.

  ### Changes by category

  **Three empty catches now Debug-log instead of silently swallowing:**
  - `HopsComponent.cs:671` — function-source menu HTTP fetch + JSON parse failure. Previously: silent. Now: `HopsLog.Log.Debug(ex, "Failed to load function-source menu for {SourcePath}",
  row.SourcePath)`.
  - `HopsComponent.cs:706` — right-click "open document" handler. Previously: silent. Now: Debug log with the document name.
  - `RemoteDefinition.cs:521` — custom-icon parsing (SVG/PNG). Previously: silent on a corrupt icon. Now: Debug log.

  **Four catch-all → `JsonException` to make intentional JSON-fallback paths type-safe:**
  - `HopsComponent.cs:993` (`DecodeJsonString` fallback) — was catching everything; now narrowed to `JsonException`, with a comment explaining the fallback intent. Truly unexpected exceptions now
  propagate.
  - `RemoteDefinition.cs:75` (`ExtractServerErrorMessage`'s `JToken.Parse`) — narrowed.
  - `RemoteDefinition.cs:662` (`SafeSchemaDeserialize`) — narrowed.
  - `RemoteDefinition.cs:1034` (`DecodeJsonString` fallback) — narrowed.

  **Two bound-check catches narrowed + use `ex.Message` instead of `ex.ToString()`:**
  - `RemoteDefinition.cs:1168` (min-bound check) — was `catch (Exception ex) { errors.Add(ex.ToString()); ... }`. The `ex.ToString()` produces a multi-line block including the full stack trace,
  surfaced to the user as a Hops component error. Now catches only `FormatException`, `OverflowException`, `InvalidCastException` (what `Convert.ToDouble` can actually throw) and surfaces a single-line
   `ex.Message` with context about which bound-check the conversion was for.
  - `RemoteDefinition.cs:1188` (max-bound check) — same pattern.

  ### Six sites intentionally NOT changed

  - `HopsComponent.cs:396` — internalized-definition deserialize failure; already surfaces via `HopsAddRuntimeMessage(Error)`.
  - `HopsComponent.cs:758` — mouse double-click handler; already surfaces via `HopsAddRuntimeMessage(Error)`.
  - `HopsComponent.cs:1051` — default-value-parsing; already surfaces via `HopsAddRuntimeMessage(Error)`.
  - `RemoteDefinition.cs:239` — URL probe in `GetPathType`; catch-all is the intentional design ("any failure → NonresponsiveUrl").
  - `RemoteDefinition.cs:452` — `responseTask.Result` handler; already does the correct `AggregateException` unwrap + surfaces detailed cancellation/network error messages.
  - Nothing skipped without explicit rationale in the table.

  ## Test plan
  - [x] Build succeeds (0 errors, 0 warnings).
  - [ ] Round-trip a Hops definition: still works the same on the happy path (no catches fired).
  - [ ] Set a parameter's min/max to a non-numeric value or trigger bounds-check failure: the error message on the component should now be a clean one-liner (not a stack trace).
  - [ ] Point Hops at a server source with a malformed icon: should still load definition normally; the icon-parse failure is now in the Hops log file at Debug level instead of being completely silent.
  - [ ] Function-source menu populates normally for a healthy source; silent skip preserved (now Debug-logged) for a broken source.