### PR TITLE
compute.geometry: consolidate per-input Debug logs in SetInputs into …

### DIFF
--- a/src/compute.geometry/GrasshopperDefinition.cs
+++ b/src/compute.geometry/GrasshopperDefinition.cs
@@ -316,6 +316,11 @@ namespace compute.geometry
 
         public void SetInputs(List<Resthopper.IO.DataTree<ResthopperObject>> values)
         {
+            // Collect names of inputs that were actually updated vs ones whose value was already
+            // current, and log each group as a single summary line after the loop. With many
+            // parameters and one changed value, per-input messages drowned out anything useful.
+            var updatedInputs = new List<string>();
+            var skippedInputs = new List<string>();
             foreach (var tree in values)
             {
                 if( !input.TryGetValue(tree.ParamName, out var inputGroup))
@@ -325,10 +330,11 @@ namespace compute.geometry
 
                 if (inputGroup.AlreadySet(tree))
                 {
-                    LogDebug("Skipping input tree... same input");
+                    skippedInputs.Add(tree.ParamName);
                     continue;
                 }
 
+                updatedInputs.Add(tree.ParamName);
                 inputGroup.CacheTree(tree);
 
                 IGH_ContextualParameter contextualParameter = inputGroup.Param as IGH_ContextualParameter;
@@ -395,6 +401,10 @@ namespace compute.geometry
                     AddTreeData(inputGroup.Param, tree, convert);
             }
 
+            if (updatedInputs.Count > 0)
+                LogDebug($"Setting values for {updatedInputs.Count} input{(updatedInputs.Count == 1 ? "" : "s")}: {string.Join(", ", updatedInputs)}");
+            if (skippedInputs.Count > 0)
+                LogDebug($"Skipping {skippedInputs.Count} unchanged input{(skippedInputs.Count == 1 ? "" : "s")}: {string.Join(", ", skippedInputs)}");
         }
 
         // Shared write path for SetInputs' regular-parameter dispatch. Each Param_X case

--- a/src/compute.geometry/ResthopperEndpoints.cs
+++ b/src/compute.geometry/ResthopperEndpoints.cs
@@ -99,7 +99,6 @@ namespace compute.geometry
             }
             int recursionLevel = input.RecursionLevel + 1;
             definition.Definition.DefineConstant("ComputeRecursionLevel", new Grasshopper.Kernel.Expressions.GH_Variant(recursionLevel));
-            Serilog.Log.Debug("Setting input values");
             definition.SetInputs(input.Values);
             long decodeTime = stopwatch.ElapsedMilliseconds;
             stopwatch.Restart();


### PR DESCRIPTION
…per-solve summary lines

## Summary
  Replaced the noisy per-input Debug logs in `SetInputs` with two summary lines per solve. Previously, a Hops component with N input parameters and one changed value would emit N-1 identical "Skipping
  input tree... same input" Debug lines plus a bland "Setting input values" with no detail — useless for diagnosing anything.

  ### New log shape (Debug level)

  Inside `GrasshopperDefinition.SetInputs`, the loop now collects two lists (`updatedInputs`, `skippedInputs`) and emits at most one summary line per group at the end:

  - `Setting values for N input(s): name1, name2, ...`
  - `Skipping N unchanged input(s): name1, name2, ...`

  Each line fires only when its list is non-empty, so a "set everything" call produces just the first line, an "everything cached" call produces just the second, and an empty call produces nothing.

  ### Removed

  - The bland `Serilog.Log.Debug("Setting input values")` in `ResthopperEndpoints.GrasshopperSolveHelper` — superseded by the new informative log inside `SetInputs`.

  No behavior change; Debug-level only. Production deployments (without `RHINO_COMPUTE_DEBUG=true`) see no log output from these sites either way.

  ## Test plan
  - [x] Build succeeds.
  - [x] Hops solve with all inputs changed: one `Setting values for N inputs: ...` line, no `Skipping` line.
  - [x] Hops solve with one input changed and N-1 unchanged: both lines, each listing the appropriate names.
  - [x] Hops solve with all inputs cached/unchanged: only the `Skipping` line.