### PR TITLE
compute.geometry: use Response.Headers indexer for Server-Timing (ASP…

### DIFF
--- a/src/compute.geometry/ResthopperEndpoints.cs
+++ b/src/compute.geometry/ResthopperEndpoints.cs
@@ -112,7 +112,7 @@ namespace compute.geometry
             stopwatch.Restart();
             string returnJson = JsonConvert.SerializeObject(output, GeometryResolver.Settings(input.DataVersion));
             long encodeTime = stopwatch.ElapsedMilliseconds;
-            ctx.Response.Headers.Add("Server-Timing", $"decode;dur={decodeTime}, solve;dur={solveTime}, encode;dur={encodeTime}");
+            ctx.Response.Headers["Server-Timing"] = $"decode;dur={decodeTime}, solve;dur={solveTime}, encode;dur={encodeTime}";
             if (definition.HasErrors)
                 ctx.Response.StatusCode = 500; // internal server error
             else


### PR DESCRIPTION
…0019)

## Summary
  Fix the `ASP0019` analyzer warning on the one site in `ResthopperEndpoints.cs` that uses `ctx.Response.Headers.Add(...)`. `IHeaderDictionary.Add` throws `ArgumentException` if the key is already
  present (because it implements `IDictionary.Add` semantics, not the friendly "append or set" pattern). Switched to the indexer assignment, which replaces any existing value — the right semantic for
  the `Server-Timing` header here since the value is a single comma-separated string constructed in one place.

  ```diff
  - ctx.Response.Headers.Add("Server-Timing", $"decode;dur={decodeTime}, solve;dur={solveTime}, encode;dur={encodeTime}");
  + ctx.Response.Headers["Server-Timing"] = $"decode;dur={decodeTime}, solve;dur={solveTime}, encode;dur={encodeTime}";

  In practice no one was hitting the ArgumentException because nothing else in our pipeline sets Server-Timing, but the analyzer is right that Add is the wrong API. No other sites in the three projects
   use IHeaderDictionary.Add — the rest of the Headers.Add(...) matches in the codebase are all on HttpRequestHeaders / HttpRequestMessage.Headers (client-side, different type, not subject to ASP0019).

  Test plan

  - Build succeeds (0 errors, 1 fewer warning than before — ASP0019 gone).
  - Normal /grasshopper solve still returns the Server-Timing header in the response.