### PR TITLE
Hops: catch network failures in Solve() to prevent macOS crash (RH-86…

### DIFF
--- a/src/hops/RemoteDefinition.cs
+++ b/src/hops/RemoteDefinition.cs
@@ -702,13 +702,15 @@ namespace Hops
             using (var request = new System.Net.Http.HttpRequestMessage(System.Net.Http.HttpMethod.Post, solveUrl) { Content = content })
             using (var cts = CreateTimeoutCts())
             {
+                var sw = Stopwatch.StartNew();
+                try
+                {
                 AddApiKeyHeader(request);
                 var postTask = HttpClient.SendAsync(request, cts.Token);
                 var fileNameMsg = String.Empty;
                 if (!String.IsNullOrEmpty(inputSchema.FileName))
                     fileNameMsg = $" with {inputSchema.FileName} input values";
                 HopsLog.Log.Debug($"Sending POST request to {solveUrl}{fileNameMsg}");
-                var sw = Stopwatch.StartNew();
                 var responseMessage = postTask.Result;
                 HopsLog.Log.Debug($"Received response {responseMessage.StatusCode} in {sw.ElapsedMilliseconds}ms");
                 var remoteSolvedData = responseMessage.Content;
@@ -838,6 +840,38 @@ namespace Hops
                 }
                 cacheKey = schema?.Pointer;
                 return schema;
+                }
+                catch (Exception ex)
+                {
+                    // Surface cancellation (HttpTimeout exceeded) or network failure (server
+                    // unreachable, DNS, connection refused) as a clear runtime message on the
+                    // component instead of letting AggregateException bubble up through
+                    // SolveInstance — that's been observed to crash Rhino on macOS (RH-86675).
+                    // .Result wraps the underlying failure in AggregateException; unwrap one
+                    // level so the message is clean.
+                    var inner = ex is AggregateException ae && ae.InnerException != null
+                        ? ae.InnerException
+                        : ex;
+                    string serverMessage;
+                    if (inner is OperationCanceledException)
+                    {
+                        serverMessage = $"Could not reach the compute server at {solveUrl}\r\nRequest timed out after {sw.Elapsed.TotalSeconds:0.0}s (configured timeout: {HopsAppSettings.HttpTimeout}s — raise it in the Hops settings panel if the server is just slow).";
+                    }
+                    else
+                    {
+                        // Network-level failure (HttpRequestException / SocketException — typically
+                        // connection refused, DNS, or TCP-stack timeout from the OS). The TCP-level
+                        // timeout will often fire before the configured HttpTimeout, so include
+                        // both the actual elapsed time AND the configured timeout so the user
+                        // can tell which layer gave up first.
+                        serverMessage = $"Could not reach the compute server at {solveUrl}\r\n{inner.Message}\r\nFailed after {sw.Elapsed.TotalSeconds:0.0}s (configured HTTP timeout: {HopsAppSettings.HttpTimeout}s).";
+                    }
+                    HopsLog.Log.Error(serverMessage);
+                    var badSchema = new Schema();
+                    badSchema.Errors.Add(serverMessage);
+                    parentComponent.HttpRecord.Schema = badSchema;
+                    return badSchema;
+                }
             }
         }
 


### PR DESCRIPTION
…675)

 ## Summary
  Fixes RH-86675 (Rhino crashes on macOS when Hops sends a request to a non-running server) and improves the user-visible error message from RH-90615 ("AggregateException: One or more errors
  occurred").

  ### Root cause

  `RemoteDefinition.Solve()` has two `postTask.Result` calls (primary POST and auto-upload retry POST) with no try/catch around them. When the server is unreachable, `.Result` throws
  `AggregateException(TaskCanceledException)` (Hops cancellation timeout) or `AggregateException(HttpRequestException)` (network-level connection failure). The exception propagates up through
  `SolveInstance` to Grasshopper's framework.

  - On Windows, GH catches it and shows a runtime error.
  - On macOS, the .NET hosting model under Eto handles unhandled UI-thread exceptions differently and Rhino can crash.

  We added exactly this protection for `GetRemoteDescription()` in PR #911 — but the Solve path was missed. This PR applies the same defensive pattern.

  ### Fix

  Wrap the body of `Solve()`'s outermost `using (cts)` block in try/catch. The catch:
  - Unwraps the `AggregateException` to get the inner exception.
  - Distinguishes `OperationCanceledException` (Hops cancellation timeout) from other exceptions (network-level connect-refused / DNS / TCP-stack timeout).
  - Always includes timing context: elapsed time + configured `HttpTimeout`, so the user can tell which layer gave up first.

  Sample messages (Hops component error display):

  **Hops cancellation timeout** (Hops's CancellationToken fired):
  > Could not reach the compute server at \<url\>/grasshopper
  > Request timed out after Ns (configured timeout: Ms — raise it in the Hops settings panel if the server is just slow).

  **Connection refused** (server not listening):
  > Could not reach the compute server at http://localhost:9999/grasshopper
  > No connection could be made because the target machine actively refused it. (localhost:9999)
  > Failed after 0.0s (configured HTTP timeout: 30s).

  **TCP-stack timeout** (host unreachable, OS gives up before Hops's timer):
  > Could not reach the compute server at http://192.168.250.1/grasshopper
  > A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.
  (192.168.250.1:80)
  > Failed after 21.1s (configured HTTP timeout: 30s).

  The third line on the non-cancellation case is important: it shows the user that a lower-level timeout fired before their configured `HttpTimeout`, so raising the configured value wouldn't help —
  they need to fix the network config or URL.

  ### What does NOT change

  - All existing return paths inside Solve (401 Unauthorized, 408 RequestTimeout-as-status-code, 500 InternalServerError with auto-upload retry, OK, etc.) work unchanged.
  - The retry POST sits inside the wrapped block, so a connection failure on the retry path is also caught uniformly.
  - The body's indentation was kept as-is (the wrapping `try { }` braces sit one level out from the inner statements). Cosmetically slightly off but minimizes diff size for review.

  ### macOS verification

  I don't have a macOS dev environment for this branch. The fix is direct and pattern-matched against PR #911's known-good `GetRemoteDescription` handler. Confidence is high that it eliminates the
  crash; please verify with one of the affected macOS users if possible.

  ## Test plan
  - [x] Build succeeds.
  - [x] **Windows happy path**: solve via Hops against a running server still works (verified by first hitting `http://localhost:6500` successfully).
  - [x] **Windows connection refused**: change URL to `http://localhost:9999` mid-session, next solve shows clean two-line "Could not reach the compute server" message + Failed-after line. No crash, no
   `AggregateException` in logs.
  - [x] **Windows TCP-stack timeout**: change URL to `http://192.168.250.1` (host unreachable), next solve shows the three-line message with both `Failed after 21.1s` and `(configured HTTP timeout:
  30s)`. The user can see that the TCP layer gave up before the configured timeout was reached.
  - [ ] **macOS crash test**: post-merge verification by an affected macOS user; should produce the same error messages as Windows with no crash.