### PR TITLE
9.x: backport 8.x v5 — Hops + /validate + stream-deserialize

### DIFF
--- a/src/compute.geometry/GeometryEndPoint.cs
+++ b/src/compute.geometry/GeometryEndPoint.cs
@@ -367,21 +367,34 @@ namespace compute.geometry
                 return;
             }
 
-            var jsonString = await new System.IO.StreamReader(context.Request.Body).ReadToEndAsync();
+            // The POST body is expected to be a JSON array of arguments. Stream-deserialize
+            // directly into a JArray rather than materializing the body as a string first —
+            // saves ~MaxRequestSize bytes of peak memory per request (default 50 MB).
+            // Reject anything that's not a JSON array (other JSON shapes, malformed JSON, or an
+            // empty body) with a 400 — this is a client-input boundary, so a bad shape is a 400,
+            // not a 500.
+            //
+            // When the debug StopAt.BodyToString checkpoint is requested, fall back to the
+            // original body-to-string read so the timing semantics of that profiling stage are
+            // preserved exactly (used by some workflows to measure body-receive latency).
+            Newtonsoft.Json.Linq.JArray ja = null;
             if (StopAt.BodyToString == stopat)
             {
+                var jsonString = await new System.IO.StreamReader(context.Request.Body).ReadToEndAsync();
                 await context.Response.WriteAsync($"{(DateTime.Now - start).TotalSeconds}");
                 return;
             }
-
-            // The POST body is expected to be a JSON array of arguments. Deserialize to the
-            // expected shape and reject anything else (non-array JSON, malformed JSON, or an
-            // empty body) with a 400 — otherwise a null `ja` would NullReference below. This
-            // is a client-input boundary, so a bad shape is a 400, not a 500.
-            Newtonsoft.Json.Linq.JArray ja = null;
-            if (!string.IsNullOrWhiteSpace(jsonString))
+            // Async reads via JsonTextReader.ReadAsync + JArray.LoadAsync so the underlying
+            // reads on Request.Body are async — Kestrel disallows synchronous IO on the
+            // request stream by default.
+            using (var streamReader = new System.IO.StreamReader(context.Request.Body))
+            using (var jsonReader = new Newtonsoft.Json.JsonTextReader(streamReader))
             {
-                try { ja = JsonConvert.DeserializeObject(jsonString) as Newtonsoft.Json.Linq.JArray; }
+                try
+                {
+                    if (await jsonReader.ReadAsync() && jsonReader.TokenType == Newtonsoft.Json.JsonToken.StartArray)
+                        ja = await Newtonsoft.Json.Linq.JArray.LoadAsync(jsonReader);
+                }
                 catch (Newtonsoft.Json.JsonException) { ja = null; }
             }
             if (ja == null)

--- a/src/compute.geometry/GrasshopperDefinition.cs
+++ b/src/compute.geometry/GrasshopperDefinition.cs
@@ -316,6 +316,14 @@ namespace compute.geometry
 
         public void SetInputs(Schema inputSchema)
         {
+            // Collect names of inputs that were actually updated vs ones whose value was already
+            // current, and log each group as a single summary line at the end. With many
+            // parameters and one changed value, per-input messages drowned out anything useful.
+            // Both wire formats (Grasshopper and the legacy DataTree<ResthopperObject>) feed
+            // into the same two lists so the log output is consistent across them.
+            var updatedInputs = new List<string>();
+            var skippedInputs = new List<string>();
+
             if(inputSchema.DataFormat == SchemaDataFormat.Grasshopper)
             {
                 foreach (var entry in inputSchema.GrasshopperValues.Values)
@@ -324,6 +332,7 @@ namespace compute.geometry
                     {
                         continue;
                     }
+                    updatedInputs.Add(entry.Key);
                     inputGroup.Param.ClearData();
                     inputGroup.Param.ExpireSolution(false); // mark param as expired but don't recompute just yet!
                     inputGroup.Param.AddVolatileDataTree(entry.Value);
@@ -340,10 +349,11 @@ namespace compute.geometry
 
                     if (inputGroup.AlreadySet(tree))
                     {
-                        LogDebug("Skipping input tree... same input");
+                        skippedInputs.Add(tree.ParamName);
                         continue;
                     }
 
+                    updatedInputs.Add(tree.ParamName);
                     inputGroup.CacheTree(tree);
 
                     IGH_ContextualParameter contextualParameter = inputGroup.Param as IGH_ContextualParameter;
@@ -411,6 +421,34 @@ namespace compute.geometry
                     };
                     if (convert != null)
                         AddTreeData(inputGroup.Param, tree, convert);
+                }
+            }
+
+            if (inputSchema.DataFormat == SchemaDataFormat.Grasshopper)
+            {
+                // The Grasshopper wire format ships a full archive of model objects on every
+                // solve, so per-input set/skip accounting isn't meaningful here — every entry
+                // we processed got applied. Emit a count-only heartbeat so the line is honest
+                // (we can't tell what the user actually changed without diffing the archive
+                // against the previous solve, which isn't worth the cost).
+                if (updatedInputs.Count > 0)
+                {
+                    string valueWord = updatedInputs.Count == 1 ? "value" : "values";
+                    LogDebug($"Applied {updatedInputs.Count} input parameter {valueWord}");
+                }
+            }
+            else
+            {
+                if (updatedInputs.Count > 0)
+                {
+                    string valueWord = updatedInputs.Count == 1 ? "value" : "values";
+                    string inputWord = updatedInputs.Count == 1 ? "input" : "inputs";
+                    LogDebug($"Setting {valueWord} for {updatedInputs.Count} {inputWord}: {string.Join(", ", updatedInputs)}");
+                }
+                if (skippedInputs.Count > 0)
+                {
+                    string inputWord = skippedInputs.Count == 1 ? "input" : "inputs";
+                    LogDebug($"Skipping {skippedInputs.Count} unchanged {inputWord}: {string.Join(", ", skippedInputs)}");
                 }
             }
         }

--- a/src/compute.geometry/ResthopperEndpoints.cs
+++ b/src/compute.geometry/ResthopperEndpoints.cs
@@ -191,11 +191,24 @@ namespace compute.geometry
             string fileName = String.Empty;
             if (asPost)
             {
-                var body = await new System.IO.StreamReader(ctx.Request.Body).ReadToEndAsync();
-                if (body.StartsWith("[") && body.EndsWith("]"))
-                    body = body.Substring(1, body.Length - 2);
-
-                Schema input = JsonConvert.DeserializeObject<Schema>(body);
+                // Stream-deserialize the request body asynchronously instead of materializing
+                // it as a string first. Saves ~MaxRequestSize bytes of peak memory per request
+                // (default 50 MB) since we don't hold both the stream buffer AND a full string
+                // copy in memory at the same time. Uses Newtonsoft's async APIs (ReadFromAsync,
+                // ReadAsync) so the underlying reads on Request.Body are async — Kestrel
+                // disallows synchronous IO on the request stream by default.
+                //
+                // Historical request shape: the body is sometimes wrapped in a single-element
+                // JSON array (`[{...}]`). Detect that via the parsed token kind and unwrap.
+                Schema input;
+                using (var streamReader = new System.IO.StreamReader(ctx.Request.Body))
+                using (var jsonReader = new Newtonsoft.Json.JsonTextReader(streamReader))
+                {
+                    var token = await Newtonsoft.Json.Linq.JToken.ReadFromAsync(jsonReader);
+                    if (token is Newtonsoft.Json.Linq.JArray ja && ja.Count > 0)
+                        token = ja[0];
+                    input = token.ToObject<Schema>();
+                }
 
                 string httpType = ctx.Request.IsHttps ? "HTTPS" : "HTTP";
                 string endpoint = ctx.GetEndpoint().DisplayName;

--- a/src/compute.geometry/Startup.cs
+++ b/src/compute.geometry/Startup.cs
@@ -77,10 +77,46 @@ namespace compute.geometry
             app.UseEndpoints(builder =>
             {
                 builder.MapHealthChecks("/healthcheck");
+                MapValidateEndpoint(builder);
                 FixedEndPointsModule.MapEndpoints(builder);
                 ResthopperEndpointsModule.MapEndpoints(builder);
                 RhinoGetModule.MapEndpoints(builder);
                 RhinoPostModule.MapEndpoints(builder);
+            });
+        }
+
+        // Liveness + API-key validation in one hop, so the Hops settings probe doesn't have
+        // to fall back to /version (which wakes children, blowing the 3-second probe budget
+        // on cold start) just to find out whether the configured key is correct. Always
+        // performs the key check in the handler — the compute.geometry ApiKeyMiddleware
+        // exempts GET, so we can't rely on the middleware to enforce it here.
+        static void MapValidateEndpoint(Microsoft.AspNetCore.Routing.IEndpointRouteBuilder builder)
+        {
+            builder.MapGet("/validate", async ctx =>
+            {
+                string configured = Config.ApiKey ?? "";
+                if (string.IsNullOrEmpty(configured))
+                {
+                    ctx.Response.StatusCode = 200;
+                    await ctx.Response.WriteAsync("Valid (no API key configured)");
+                    return;
+                }
+                if (!ctx.Request.Headers.TryGetValue("RhinoComputeKey", out var provided))
+                {
+                    ctx.Response.StatusCode = 401;
+                    await ctx.Response.WriteAsync("Api Key was not provided.");
+                    return;
+                }
+                var providedBytes = System.Text.Encoding.UTF8.GetBytes(provided.ToString());
+                var configuredBytes = System.Text.Encoding.UTF8.GetBytes(configured);
+                if (!System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(providedBytes, configuredBytes))
+                {
+                    ctx.Response.StatusCode = 401;
+                    await ctx.Response.WriteAsync("Unauthorized client.");
+                    return;
+                }
+                ctx.Response.StatusCode = 200;
+                await ctx.Response.WriteAsync("Valid");
             });
         }
 

--- a/src/hops/HopsComponent.cs
+++ b/src/hops/HopsComponent.cs
@@ -668,8 +668,9 @@ namespace Hops
                         }
                     }
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
+                    HopsLog.Log.Debug(ex, "Failed to load function-source menu for {SourcePath}", row.SourcePath);
                 }
             }
             else if (Directory.Exists(row.SourcePath))
@@ -703,7 +704,10 @@ namespace Hops
                     {
                         Instances.DocumentEditor.ScriptAccess_OpenDocument(ti.Name);
                     }
-                    catch (Exception) { }
+                    catch (Exception ex)
+                    {
+                        HopsLog.Log.Debug(ex, "Failed to open document {DocumentName}", ti.Name);
+                    }
                     break;
             }
             
@@ -997,8 +1001,10 @@ for value in values:
             {
                 return JsonConvert.DeserializeObject<string>(data);
             }
-            catch (Exception)
+            catch (Newtonsoft.Json.JsonException)
             {
+                // Intentional fallback: when the data isn't valid JSON-encoded string syntax,
+                // treat it as already-decoded and just unescape any backslash sequences.
                 return System.Text.RegularExpressions.Regex.Unescape(data);
             }
         }

--- a/src/hops/RemoteDefinition.cs
+++ b/src/hops/RemoteDefinition.cs
@@ -73,7 +73,7 @@ namespace Hops
                         message = m;
                 }
             }
-            catch (Exception)
+            catch (Newtonsoft.Json.JsonException)
             {
                 // not JSON — keep the raw body
             }
@@ -530,8 +530,9 @@ namespace Hops
                             }
                         }
                     }
-                    catch(Exception)
+                    catch (Exception ex)
                     {
+                        HopsLog.Log.Debug(ex, "Failed to parse custom icon for remote definition at {Path}", Path);
                     }
                 }
 
@@ -672,8 +673,10 @@ namespace Hops
             {
                 return JsonConvert.DeserializeObject<Resthopper.IO.Schema>(data);
             }
-            catch (Exception)
+            catch (Newtonsoft.Json.JsonException)
             {
+                // Method-name promises "safe" — caller treats null as parse failure and
+                // handles it via the bad-schema / status-code paths.
             }
             return null;
         }
@@ -712,13 +715,15 @@ namespace Hops
             using (var request = new System.Net.Http.HttpRequestMessage(System.Net.Http.HttpMethod.Post, solveUrl) { Content = content })
             using (var cts = CreateTimeoutCts())
             {
+                var sw = Stopwatch.StartNew();
+                try
+                {
                 AddApiKeyHeader(request);
                 var postTask = HttpClient.SendAsync(request, cts.Token);
                 var fileNameMsg = String.Empty;
                 if (!String.IsNullOrEmpty(inputSchema.FileName))
                     fileNameMsg = $" with {inputSchema.FileName} input values";
                 HopsLog.Log.Debug($"Sending POST request to {solveUrl}{fileNameMsg}");
-                var sw = Stopwatch.StartNew();
                 var responseMessage = postTask.Result;
                 HopsLog.Log.Debug($"Received response {responseMessage.StatusCode} in {sw.ElapsedMilliseconds}ms");
                 var remoteSolvedData = responseMessage.Content;
@@ -852,6 +857,38 @@ namespace Hops
                 }
                 cacheKey = schema.Pointer;
                 return schema;
+                }
+                catch (Exception ex)
+                {
+                    // Surface cancellation (HttpTimeout exceeded) or network failure (server
+                    // unreachable, DNS, connection refused) as a clear runtime message on the
+                    // component instead of letting AggregateException bubble up through
+                    // SolveInstance — that's been observed to crash Rhino on macOS (RH-86675).
+                    // .Result wraps the underlying failure in AggregateException; unwrap one
+                    // level so the message is clean.
+                    var inner = ex is AggregateException ae && ae.InnerException != null
+                        ? ae.InnerException
+                        : ex;
+                    string serverMessage;
+                    if (inner is OperationCanceledException)
+                    {
+                        serverMessage = $"Could not reach the compute server at {solveUrl}\r\nRequest timed out after {sw.Elapsed.TotalSeconds:0.0}s (configured timeout: {HopsAppSettings.HttpTimeout}s — raise it in the Hops settings panel if the server is just slow).";
+                    }
+                    else
+                    {
+                        // Network-level failure (HttpRequestException / SocketException — typically
+                        // connection refused, DNS, or TCP-stack timeout from the OS). The TCP-level
+                        // timeout will often fire before the configured HttpTimeout, so include
+                        // both the actual elapsed time AND the configured timeout so the user
+                        // can tell which layer gave up first.
+                        serverMessage = $"Could not reach the compute server at {solveUrl}\r\n{inner.Message}\r\nFailed after {sw.Elapsed.TotalSeconds:0.0}s (configured HTTP timeout: {HopsAppSettings.HttpTimeout}s).";
+                    }
+                    HopsLog.Log.Error(serverMessage);
+                    var badSchema = new Schema();
+                    badSchema.Errors.Add(serverMessage);
+                    parentComponent.HttpRecord.Schema = badSchema;
+                    return badSchema;
+                }
             }
         }
 
@@ -980,8 +1017,10 @@ namespace Hops
             {
                 return JsonConvert.DeserializeObject<string>(objData);
             }
-            catch (Exception)
+            catch (Newtonsoft.Json.JsonException)
             {
+                // Intentional fallback: when objData isn't valid JSON-encoded string syntax,
+                // treat it as already-decoded and just strip wrapping quotes / unescape.
                 return MaybeUnescapeJsonString(objData.Trim('"'));
             }
         }
@@ -1208,9 +1247,11 @@ namespace Hops
                         return false;
                     }
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ex is FormatException || ex is OverflowException || ex is InvalidCastException)
                 {
-                    errors.Add(ex.ToString());
+                    // Conversion of `item` or `min` to double failed. Surface the short error
+                    // message rather than the full ex.ToString() (which includes the stack trace).
+                    errors.Add($"{name} value could not be evaluated for the minimum-bound check: {ex.Message}");
                     return false;
                 }
 
@@ -1228,9 +1269,11 @@ namespace Hops
                         return false;
                     }
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ex is FormatException || ex is OverflowException || ex is InvalidCastException)
                 {
-                    errors.Add(ex.ToString());
+                    // Conversion of `item` or `max` to double failed. Surface the short error
+                    // message rather than the full ex.ToString() (which includes the stack trace).
+                    errors.Add($"{name} value could not be evaluated for the maximum-bound check: {ex.Message}");
                     return false;
                 }
             }

--- a/src/hops/Servers.cs
+++ b/src/hops/Servers.cs
@@ -177,13 +177,21 @@ namespace Hops
             var existingProcesses = Process.GetProcessesByName("rhino.compute");
             if( existingProcesses!=null && existingProcesses.Length>0)
             {
-                if (IsPortOpen("localhost", RhinoComputePort, new TimeSpan(0, 0, 0, 0, 100)))
+                // 1-second timeout instead of 100ms. The shorter window can flap when the
+                // existing rhino.compute is busy serving a request, leading the check to
+                // think the port isn't reachable and falling through to spawn a duplicate.
+                if (IsPortOpen("localhost", RhinoComputePort, TimeSpan.FromSeconds(1)))
                 {
                     serverQueue.Enqueue(new ComputeServer(existingProcesses[0], RhinoComputePort));
+                    // Critical: bail out so we don't fall through to spawn a *second*
+                    // rhino.compute that immediately exits because the port is taken.
+                    // Without this return, every Hops solve triggered a transient console
+                    // window each time GetComputeServerBaseUrl had to rebuild the queue.
+                    return;
                 }
             }
 
-            // No rhino.compute.exe running. Launch one
+            // No rhino.compute.exe running (or its port wasn't reachable). Launch one.
             string dir = null;
             if (GhaAssemblyInfo.TheAssemblyInfo != null)
             {

--- a/src/rhino.compute/Startup.cs
+++ b/src/rhino.compute/Startup.cs
@@ -69,7 +69,44 @@
             app.UseEndpoints(builder =>
             {
                 builder.MapHealthChecks("/healthcheck");
+                MapValidateEndpoint(builder);
                 ReverseProxyModule.MapEndpoints(builder);
+            });
+        }
+
+        // Liveness + API-key validation in one hop, so the Hops settings probe doesn't have
+        // to fall back to /version (which wakes children, blowing the 3-second probe budget
+        // on cold start) just to find out whether the configured key is correct. When
+        // Config.ApiKey is set, the rhino.compute ApiKeyMiddleware will already have
+        // checked the key for us — the handler's own check is defensive and also covers
+        // the no-key-configured case where the middleware isn't registered.
+        static void MapValidateEndpoint(Microsoft.AspNetCore.Routing.IEndpointRouteBuilder builder)
+        {
+            builder.MapGet("/validate", async ctx =>
+            {
+                string configured = Config.ApiKey ?? "";
+                if (string.IsNullOrEmpty(configured))
+                {
+                    ctx.Response.StatusCode = 200;
+                    await ctx.Response.WriteAsync("Valid (no API key configured)");
+                    return;
+                }
+                if (!ctx.Request.Headers.TryGetValue("RhinoComputeKey", out var provided))
+                {
+                    ctx.Response.StatusCode = 401;
+                    await ctx.Response.WriteAsync("Api Key was not provided.");
+                    return;
+                }
+                var providedBytes = System.Text.Encoding.UTF8.GetBytes(provided.ToString());
+                var configuredBytes = System.Text.Encoding.UTF8.GetBytes(configured);
+                if (!System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(providedBytes, configuredBytes))
+                {
+                    ctx.Response.StatusCode = 401;
+                    await ctx.Response.WriteAsync("Unauthorized client.");
+                    return;
+                }
+                ctx.Response.StatusCode = 200;
+                await ctx.Response.WriteAsync("Valid");
             });
         }
     }


### PR DESCRIPTION
## Summary
  - Backports 8.x PRs **#922 – #927** plus the auto-spawn dedup portion of **#929** to 9.x. Hops UI redesign portion of #929 is intentionally **not**
  here — it depends on `System.Windows.Forms.RadioButton` which Rhino-on-Mac's WinForms shim doesn't ship yet (YouTrack with Curtis).
  - **compute.geometry**: POST bodies on `/io` and the reflected `/{*uri}` endpoint now stream-deserialize via Newtonsoft's async APIs instead of
  materializing as strings first — saves ~`MaxRequestSize` peak memory per request (default 50 MB). The `?stopat=2` debug-profiling stage still does
  the original body-to-string read so its timing semantics are exact. Per-input `SetInputs` `Debug` logs consolidated to one summary line per solve.
  Both wire formats supported with correct singular/plural across `input(s)` and `value(s)`: legacy `DataTree<ResthopperObject>` emits `Setting
  value(s) for N input(s): X, Y, Z` plus optional `Skipping N unchanged input(s): X, Y, Z`; the new Rhino 9 Grasshopper wire format emits a count-only
  `Applied N input parameter value(s)` because per-input cache-hit detection isn't meaningful there (the full model archive is applied every solve).
  - **Hops**: `catch(Exception)` blocks tightened across `HopsComponent` and `RemoteDefinition` — empty catches now `Debug`-log instead of silently
  swallowing; JSON-fallback catches narrowed to `JsonException`; bound-check catches narrowed to `FormatException | OverflowException |
  InvalidCastException` with cleaner error wording. `RemoteDefinition.Solve()` now wraps its response-handling block in try/catch that unwraps
  `AggregateException`, distinguishes `OperationCanceledException` (Hops timeout) from network failure (`HttpRequestException` / `SocketException`),
  and surfaces a clean three-line component error: URL, inner message, elapsed-vs-configured-timeout. Fixes RH-86675 (unreachable server crashes Rhino
  on macOS) and RH-90615 (cryptic `AggregateException: One or more errors occurred`).
  - **Hops**: `Servers.LaunchLocalRhinoCompute` would fall through to spawn a duplicate `rhino.compute.exe` even after detecting and enqueueing an
  existing one — every solve flashed a transient console window on local-dev setups. Added the missing `return` after enqueueing, and bumped the
  existing-process port probe from `100ms` to `1s` so the check doesn't flap when the running instance is mid-request.
  - **rhino.compute + compute.geometry**: new `GET /validate` endpoint on both projects, registered alongside `MapHealthChecks("/healthcheck")`.
  Handler does its own `RhinoComputeKey` check via `CryptographicOperations.FixedTimeEquals` and returns `200 "Valid"` (or `200 "Valid (no API key
  configured)"` when `Config.ApiKey` is empty) / `401 "Api Key was not provided."` / `401 "Unauthorized client."`. Same handler shape on both projects
  — on compute.geometry the middleware exempts GET so the handler MUST do the check itself; on rhino.compute the middleware would have caught a bad key
   first but the handler check is defensive and also covers the no-key-configured case where the middleware isn't registered.
  - **No-op vs 8.x**: PR #925 (`Response.Headers` indexer for `Server-Timing`, ASP0019) is not in this PR because 9.x already uses `Headers.Append`,
  which is the safer form ASP0019 was steering toward.

  ## Test plan
  - [ ] compute.geometry: POST a near-50 MB body to `/io` and to a reflected `/rhino/geometry/...` endpoint; both should round-trip cleanly via the
  streaming reader and `?stopat=2` should still return its timing checkpoint.
  - [ ] compute.geometry: solve a Hops component with the new Rhino 9 Grasshopper wire format; verify one `Applied N input parameter value(s)` line per
   solve with correct singular/plural at `N=1` vs `N>1`.
  - [ ] compute.geometry: solve a Hops component with the legacy `DataTree` wire format (change one input value out of many); verify the per-solve
  summary now shows `Setting value(s) for N input(s)` + `Skipping N unchanged input(s)` with correct singular/plural across `input(s)` and `value(s)`.
  - [ ] rhino.compute + compute.geometry: `GET /validate` with no header → 200 (when no key configured server-side) or 401 (when key required but
  header missing); with wrong `RhinoComputeKey` → 401; with correct key → 200 "Valid".
  - [ ] Hops: point a component at an unreachable URL; observe the clean three-line component error (URL / inner message / elapsed-vs-timeout) and
  verify Rhino does not crash on macOS.
  - [ ] Hops: launch `rhino.compute` in a debugger on port 6500, open Grasshopper with Hops set to Use Local, solve a definition repeatedly. No
  transient `rhino.compute.exe` console windows should flash.
  - [ ] Spot-check the tightened catch sites: invalid remote-definition custom icon still loads the component (Debug log surfaces in console);
  bound-check failures show the short reason instead of full stack trace.