### PR TITLE
Hops: use checkboxes for server source picker (macOS compatibility)

### DIFF
--- a/src/hops/HopsAppSettingsUserControl.Designer.cs
+++ b/src/hops/HopsAppSettingsUserControl.Designer.cs
@@ -34,13 +34,13 @@ namespace Hops
         {
             this.components = new System.ComponentModel.Container();
             this._gpboxComputeServer = new System.Windows.Forms.GroupBox();
-            this._rdoUseLocal = new System.Windows.Forms.RadioButton();
+            this._rdoUseLocal = new System.Windows.Forms.CheckBox();
             this._advancedServersButton = new System.Windows.Forms.PictureBox();
             this._hideWorkerWindows = new System.Windows.Forms.CheckBox();
             this._launchWorkerAtStart = new System.Windows.Forms.CheckBox();
             this._childComputeCount = new System.Windows.Forms.NumericUpDown();
             this._updateChildCountButton = new System.Windows.Forms.Button();
-            this._rdoUseRemote = new System.Windows.Forms.RadioButton();
+            this._rdoUseRemote = new System.Windows.Forms.CheckBox();
             this._labelServerUrl = new System.Windows.Forms.Label();
             this._serverUrlTextbox = new System.Windows.Forms.TextBox();
             this._serverStatusDot = new System.Windows.Forms.PictureBox();
@@ -336,8 +336,8 @@ namespace Hops
 
         #endregion
         private System.Windows.Forms.GroupBox _gpboxComputeServer;
-        private System.Windows.Forms.RadioButton _rdoUseLocal;
-        private System.Windows.Forms.RadioButton _rdoUseRemote;
+        private System.Windows.Forms.CheckBox _rdoUseLocal;
+        private System.Windows.Forms.CheckBox _rdoUseRemote;
         private System.Windows.Forms.Label _labelServerUrl;
         private System.Windows.Forms.TextBox _serverUrlTextbox;
         private System.Windows.Forms.PictureBox _serverStatusDot;

--- a/src/hops/HopsAppSettingsUserControl.cs
+++ b/src/hops/HopsAppSettingsUserControl.cs
@@ -85,8 +85,14 @@ namespace Hops
                 TestCurrentUrl();
             };
 
-            _rdoUseLocal.CheckedChanged += UseLocalCheckedChanged;
-            _rdoUseRemote.CheckedChanged += UseRemoteCheckedChanged;
+            // Checkboxes used as radio-button equivalents (RadioButton isn't in the macOS WinForms shim yet).
+            // AutoCheck=false + Click handler enforces exactly-one-checked: re-clicking the active box is a
+            // no-op, and clicking the other swaps both states atomically. Programmatic Checked= assignments
+            // don't fire Click, so initialization stays clean.
+            _rdoUseLocal.AutoCheck = false;
+            _rdoUseRemote.AutoCheck = false;
+            _rdoUseLocal.Click += UseLocalClicked;
+            _rdoUseRemote.Click += UseRemoteClicked;
             _serverUrlTextbox.TextChanged += ServerUrlChanged;
             _advancedServersButton.Click += AdvancedServersClicked;
             _advancedServersButton.Cursor = Cursors.Hand;
@@ -264,10 +270,8 @@ namespace Hops
             {
                 // The URL is always populated from saved Servers so toggling local/remote preserves it.
                 _serverUrlTextbox.Text = servers.Length > 0 ? servers[0] : "";
-                if (HopsAppSettings.UseLocalServer)
-                    _rdoUseLocal.Checked = true;
-                else
-                    _rdoUseRemote.Checked = true;
+                _rdoUseLocal.Checked = HopsAppSettings.UseLocalServer;
+                _rdoUseRemote.Checked = !HopsAppSettings.UseLocalServer;
             }
             finally
             {
@@ -312,18 +316,22 @@ namespace Hops
             _updateChildCountButton.Enabled = local;
         }
 
-        void UseLocalCheckedChanged(object sender, EventArgs e)
+        void UseLocalClicked(object sender, EventArgs e)
         {
-            if (!_rdoUseLocal.Checked) return;
+            if (_rdoUseLocal.Checked) return;
+            _rdoUseLocal.Checked = true;
+            _rdoUseRemote.Checked = false;
             autoTestTimer.Stop();
             HopsAppSettings.UseLocalServer = true;
             UpdateUrlControlsEnabled();
             UpdateLocalOnlyControlsEnabled();
         }
 
-        void UseRemoteCheckedChanged(object sender, EventArgs e)
+        void UseRemoteClicked(object sender, EventArgs e)
         {
-            if (!_rdoUseRemote.Checked) return;
+            if (_rdoUseRemote.Checked) return;
+            _rdoUseRemote.Checked = true;
+            _rdoUseLocal.Checked = false;
             HopsAppSettings.UseLocalServer = false;
             UpdateUrlControlsEnabled();
             UpdateLocalOnlyControlsEnabled();


### PR DESCRIPTION
## Summary

  The "Compute server source" picker introduced in PR #929 used `System.Windows.Forms.RadioButton`. That control isn't in the Rhino-on-Mac WinForms
  compatibility shim in shipping Rhino 8 builds — Curtis has a fix in flight, but the older-build tail will be 6-9 months long. Anyone who updates Hops
   to pick up the recent fixes (auto-spawn dedup, macOS Solve crash, etc.) while still on a pre-shim Rhino would hit a broken preferences panel. To
  avoid that support burden, switch to `CheckBox` controls that behave like radio buttons.

  ## Approach

  - `AutoCheck = false` on both checkboxes — clicking the control no longer auto-toggles `Checked`.
  - `Click` handler enforces exactly-one-checked: re-clicking the active box is a no-op; clicking the other swaps both `Checked` states atomically and
  runs the original side effects.
  - Programmatic `Checked =` assignments don't fire `Click`, so `InitServerSourceFromSettings` stays clean (no suppress flag needed).
  - Field names (`_rdoUseLocal` / `_rdoUseRemote`) intentionally kept so the eventual revert to `RadioButton` is a smaller diff.

  The visual difference is a square check vs. a circular dot — functionally identical.

  ## Files

  - `src/hops/HopsAppSettingsUserControl.Designer.cs` — `RadioButton` → `CheckBox` (2 constructor lines + 2 field declarations).
  - `src/hops/HopsAppSettingsUserControl.cs` — `CheckedChanged` subscriptions → `AutoCheck = false` + `Click`; handlers renamed
  `UseLocalCheckedChanged` → `UseLocalClicked` (same for Remote); `InitServerSourceFromSettings` now sets both `Checked` values explicitly since radio
  mutual-exclusion no longer does it.

  ## Future

  Revert to proper `RadioButton` once Curtis's macOS shim has shipped widely (~6-9 months).

  ## Test plan

  - [x] Windows: open Hops preferences, click Use local → Use remote → Use local; both toggle correctly, side effects run (URL field enable/disable,
  auto-test timer, local-only controls grayed when Remote).
  - [x] Windows: re-click the active option — no state change, no side effects.
  - [ ] macOS: open Hops preferences, panel renders correctly; Use local is disabled with its tooltip; Use remote is selected and editable.
  - [ ] Settings persist across Rhino restart (`Hops:UseLocalServer` round-trip).