### PR TITLE
compute.geometry: support struct-based geometry (Line/Arc/Circle) in …

### DIFF
--- a/src/compute.geometry/GrasshopperDefinition.cs
+++ b/src/compute.geometry/GrasshopperDefinition.cs
@@ -475,14 +475,41 @@ namespace compute.geometry
             }
         }
 
-        // Geometry contextual inputs arrive as a Rhino CommonObject JSON dictionary; rehydrate
-        // to GeometryBase then wrap as IGH_GeometricGoo. Original code did not null-check before
-        // adding to the tree, so we don't either (preserving behavior).
+        // Geometry contextual inputs (Param_Geometry / GetGeometry parameters) arrive in one of
+        // two wire formats depending on the client:
+        //   1. CommonObject dictionary-archive JSON — produced by Hops (which calls
+        //      GH_Convert.ToGeometryBase before sending) and by other clients that wrap
+        //      geometry through CommonObject.ToJSON. Rehydrate via CommonObject.FromJSON.
+        //   2. Flat property-bag JSON — produced by non-Hops clients (compute.rhino3d.py,
+        //      compute.rhino3d.js, custom callers) when serializing Rhino value-type structs
+        //      (Line, Arc, Circle) directly with JsonConvert. These don't derive from
+        //      CommonObject and won't rehydrate via FromJSON; deserialize as the raw struct
+        //      and wrap in the matching curve type so the downstream pipeline sees a
+        //      GeometryBase.
         static IGH_GeometricGoo DeserializeGeometry(ResthopperObject restobj)
         {
-            var dict = JsonConvert.DeserializeObject<Dictionary<string, string>>(restobj.Data);
-            var gb = Rhino.Runtime.CommonObject.FromJSON(dict) as GeometryBase;
-            return GH_Convert.ToGeometricGoo(gb);
+            try
+            {
+                var dict = JsonConvert.DeserializeObject<Dictionary<string, string>>(restobj.Data);
+                if (dict != null && Rhino.Runtime.CommonObject.FromJSON(dict) is GeometryBase gb)
+                    return GH_Convert.ToGeometricGoo(gb);
+            }
+            catch (JsonException) { /* not a CommonObject archive — fall through to struct path */ }
+
+            if (TryDeserializeStruct<Circle>(restobj.Data, out var circle) && circle.IsValid)
+                return GH_Convert.ToGeometricGoo(new ArcCurve(circle));
+            if (TryDeserializeStruct<Arc>(restobj.Data, out var arc) && arc.IsValid)
+                return GH_Convert.ToGeometricGoo(new ArcCurve(arc));
+            if (TryDeserializeStruct<Line>(restobj.Data, out var line) && line.IsValid)
+                return GH_Convert.ToGeometricGoo(new LineCurve(line));
+
+            return null;
+        }
+
+        static bool TryDeserializeStruct<T>(string data, out T value) where T : struct
+        {
+            try { value = JsonConvert.DeserializeObject<T>(data); return true; }
+            catch (JsonException) { value = default; return false; }
         }
 
         public Schema Solve(int rhinoVersion)


### PR DESCRIPTION
…Param_Geometry

## Summary

  Fixes a `RhinoCommon`/`CommonObject` serialization mismatch in `GrasshopperDefinition.DeserializeGeometry` that prevented non-Hops clients from
  sending `Line`, `Arc`, or `Circle` values into a `Param_Geometry` (`GetGeometry`) input.

  ## Background

  `DeserializeGeometry` previously assumed every contextual-geometry input arrived as a `CommonObject` dictionary-archive JSON blob and fed it straight
   into `Rhino.Runtime.CommonObject.FromJSON`. That works for `GeometryBase`-derived types (Curve, Brep, Mesh, Surface, …) but fails silently for
  Rhino's value-type structs (`Line`, `Arc`, `Circle`) — those don't derive from `CommonObject`, serialize as flat property bags (`{"From":...,
  "To":...}`), and return null from `FromJSON`. The null then propagated into the parameter tree and broke the solve.

  Hops users don't hit this because Hops calls `GH_Convert.ToGeometryBase` on the client before sending — `GH_Circle` → `ArcCurve`, `GH_Line` →
  `LineCurve`, etc. — so the wire payload is always a proper `Curve`. The bug only surfaces from non-Hops clients (`compute.rhino3d.py`,
  `compute.rhino3d.js`, custom HTTP callers) that serialize the raw struct directly.

  Reported on Discourse by Felix Brunold, who also identified the root cause and proposed the workaround this PR adopts:
  https://discourse.mcneel.com/t/getgeometry-serialization-error-for-struct-based-geometry/219626

  ## Approach

  `DeserializeGeometry` now tries both wire formats in order:

  1. Try `CommonObject.FromJSON` on the body as a dictionary archive (preserves existing behavior for Hops and any client that uses the `CommonObject`
  format).
  2. If that doesn't yield a `GeometryBase`, fall back to deserializing the body as a `Circle`/`Arc`/`Line` struct and wrap the result in the matching
  `ArcCurve`/`LineCurve` so the downstream pipeline sees a proper `GeometryBase`.

  Each struct attempt goes through a small `TryDeserializeStruct<T>` helper that swallows `JsonException` and returns false — so a body that isn't
  valid JSON for `T` just falls through to the next attempt rather than crashing the solve.

  ## Files

  - `src/compute.geometry/GrasshopperDefinition.cs` — rewrote `DeserializeGeometry` + added `TryDeserializeStruct<T>` helper. ~25 lines net.

  ## Test plan

  - [ ] Existing Hops definitions with `Param_Geometry` inputs continue to work (regression check — the `CommonObject.FromJSON` path is still tried
  first and unchanged).
  - [ ] A `compute.rhino3d.py` (or other non-Hops) client posting a raw `Circle` / `Arc` / `Line` JSON to a definition with a `GetGeometry` input now
  solves successfully instead of failing silently.
  - [ ] An invalid JSON body in a `Param_Geometry` slot returns `null` from `DeserializeGeometry` (same behavior as before — original code returned
  null via `as GeometryBase` cast, new code returns null after all three fallback attempts fail).