### PR TITLE
Set Content-Length on /grasshopper responses to prevent client hangs on large error results

### DIFF
--- a/src/compute.geometry/ResthopperEndpoints.cs
+++ b/src/compute.geometry/ResthopperEndpoints.cs
@@ -176,7 +176,13 @@ namespace compute.geometry
             if (!string.IsNullOrEmpty(json))
             {
                 ctx.Response.ContentType = "application/json";
-                await ctx.Response.WriteAsync(json);
+                // Send the body with a Content-Length header so the
+                // size is known up front. Without it, the response is sent in chunks, which
+                // the Node client fails to read on a 500 error, causing the request to hang
+                // until it times out.
+                var payload = System.Text.Encoding.UTF8.GetBytes(json);
+                ctx.Response.ContentLength = payload.Length;
+                await ctx.Response.Body.WriteAsync(payload, 0, payload.Length);
             }
         }
 


### PR DESCRIPTION
**Summary**

The /grasshopper endpoint writes its JSON response without a Content-Length header, so the body is sent with chunked transfer-encoding. I observed that when the response has an error status (HTTP 500) and a large body, the request can hang until the client times out: even though the solve completed and the full result was written. Setting an explicit Content-Length (fixed-length framing) resolves the hang.

**Observed behavior**

A definition that solves but contains component errors returns HTTP 500 with the complete result in the body (existing behavior; the result is valid, just flagged). I reproduced a case where:

The solve finished and a ~1 MB JSON body was serialized in a few seconds (confirmed by server logs).
The server reached the response write, but no bytes were sent (Response.HasStarted stayed false), and the write did not complete.
The client (Node fetch) never received the body and aborted at its configured timeout (100 s).
The same definition with a small result returned normally, and the same request routed through the rhino.compute reverse proxy (which buffers the child's full response and re-emits it) also returned normally. The hang appeared only when posting a large error response directly from a compute.geometry instance.

**Change**

In ResthopperEndpoints.Grasshopper, write the body as explicit bytes with Content-Length set instead of WriteAsync(string):

var payload = System.Text.Encoding.UTF8.GetBytes(json);
ctx.Response.ContentLength = payload.Length;
await ctx.Response.Body.WriteAsync(payload, 0, payload.Length);
Status code and payload are unchanged: only the wire framing changes (fixed length instead of chunked).

**Reproduction**

1. POST /grasshopper directly to a compute.geometry instance (not via the proxy).
2. Use a definition that produces component errors and a result large enough to need multiple TCP segments.
3. Before: request hangs, then times out. After: result returns in normal solve time.